### PR TITLE
Removed invalid argument in xsd reader service configuration

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -8,9 +8,7 @@
         <service id="goetas_webservices.xsd2php.naming_convention.long" public="false"
                  class="GoetasWebservices\Xsd\XsdToPhp\Naming\LongNamingStrategy"/>
 
-        <service id="goetas_webservices.xsd2php.schema_reader" public="true" class="GoetasWebservices\XML\XSDReader\SchemaReader">
-            <argument type="service" id="logger"/>
-        </service>
+        <service id="goetas_webservices.xsd2php.schema_reader" public="true" class="GoetasWebservices\XML\XSDReader\SchemaReader" />
 
         <service synthetic="true" public="false" id="goetas_webservices.xsd2php.naming_convention"/>
         <service synthetic="true" id="logger"/>


### PR DESCRIPTION
This PR fixes  a bug in the services configuration by removing the logger argument from the SchemaReader service configuration.