### PR TITLE
Added zend-code ^3.0.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,13 @@
     "symfony/config": "^2.2|^3.0|^4.0",
     "goetas-webservices/xsd-reader": "^0.2|^0.3.1",
     "doctrine/inflector": "^1.0",
-    "zendframework/zend-code": "~2.3|^3.0",
+    "zendframework/zend-code": "~2.3|^3.0.3",
 
     "psr/log": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8|^5.0",
-    "jms/serializer": "^1.3",
+    "jms/serializer": "^1.9",
     "goetas-webservices/xsd2php-runtime": "^0.2.7",
     "ext-xmldiff": "*"
   },

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "symfony/config": "^2.2|^3.0|^4.0",
     "goetas-webservices/xsd-reader": "^0.2|^0.3.1",
     "doctrine/inflector": "^1.0",
-    "zendframework/zend-code": "~2.3|^3.0.3",
+    "zendframework/zend-code": "^3.0.3",
 
     "psr/log": "^1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -25,14 +25,15 @@
     "symfony/config": "^2.2|^3.0|^4.0",
     "goetas-webservices/xsd-reader": "^0.2|^0.3.1",
     "doctrine/inflector": "^1.0",
-    "zendframework/zend-code": "~2.3",
+    "zendframework/zend-code": "~2.3|^3.0",
 
     "psr/log": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8|^5.0",
     "jms/serializer": "^1.3",
-    "goetas-webservices/xsd2php-runtime": "^0.2.7"
+    "goetas-webservices/xsd2php-runtime": "^0.2.7",
+    "ext-xmldiff": "*"
   },
   "autoload": {
     "psr-4": {

--- a/src/AbstractConverter.php
+++ b/src/AbstractConverter.php
@@ -68,16 +68,16 @@ abstract class AbstractConverter
         $this->logger = $logger ?: new NullLogger();
 
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "gYearMonth", function (Type $type) {
-            return "integer";
+            return "int";
         });
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "gMonthDay", function (Type $type) {
-            return "integer";
+            return "int";
         });
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "gMonth", function (Type $type) {
-            return "integer";
+            return "int";
         });
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "gYear", function (Type $type) {
-            return "integer";
+            return "int";
         });
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "NMTOKEN", function (Type $type) {
             return "string";
@@ -107,43 +107,43 @@ abstract class AbstractConverter
             return "string";
         });
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "integer", function (Type $type) {
-            return "integer";
+            return "int";
         });
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "int", function (Type $type) {
-            return "integer";
+            return "int";
         });
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "unsignedInt", function (Type $type) {
-            return "integer";
+            return "int";
         });
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "negativeInteger", function (Type $type) {
-            return "integer";
+            return "int";
         });
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "positiveInteger", function (Type $type) {
-            return "integer";
+            return "int";
         });
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "nonNegativeInteger", function (Type $type) {
-            return "integer";
+            return "int";
         });
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "nonPositiveInteger", function (Type $type) {
-            return "integer";
+            return "int";
         });
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "long", function (Type $type) {
-            return "integer";
+            return "int";
         });
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "unsignedLong", function (Type $type) {
-            return "integer";
+            return "int";
         });
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "short", function (Type $type) {
-            return "integer";
+            return "int";
         });
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "boolean", function (Type $type) {
-            return "boolean";
+            return "bool";
         });
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "nonNegativeInteger", function (Type $type) {
-            return "integer";
+            return "int";
         });
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "positiveInteger", function (Type $type) {
-            return "integer";
+            return "int";
         });
         $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "language", function (Type $type) {
             return "string";

--- a/src/Jms/YamlConverter.php
+++ b/src/Jms/YamlConverter.php
@@ -19,6 +19,7 @@ use GoetasWebservices\XML\XSDReader\Schema\Type\SimpleType;
 use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
 use GoetasWebservices\Xsd\XsdToPhp\AbstractConverter;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\NamingStrategy;
+use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass;
 
 class YamlConverter extends AbstractConverter
 {
@@ -409,7 +410,7 @@ class YamlConverter extends AbstractConverter
      * @param PHPClass $class
      * @param Schema $schema
      * @param Element $element
-     * @param boolean $arrayize
+     * @param bool $arrayize
      * @return \GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPProperty
      */
     private function visitElement(&$class, Schema $schema, ElementItem $element, $arrayize = true)

--- a/src/Php/ClassGenerator.php
+++ b/src/Php/ClassGenerator.php
@@ -46,7 +46,6 @@ class ClassGenerator
             'integer',
             'boolean',
             'array',
-            'mixed',
             'callable'
         ]);
     }
@@ -141,7 +140,7 @@ class ClassGenerator
 
         $method = new MethodGenerator("set" . Inflector::classify($prop->getName()));
 
-        $parameter = new ParameterGenerator($prop->getName(), "mixed");
+        $parameter = new ParameterGenerator($prop->getName());
 
         if ($type && $type instanceof PHPClassOf) {
             $patramTag->setTypes($type->getArg()
@@ -387,7 +386,7 @@ class ClassGenerator
                 $this->handleValueMethod($class, $p, $extends);
             } else {
 
-                $class->setExtendedClass($extends->getName());
+                $class->setExtendedClass($extends->getFullName());
 
                 if ($extends->getNamespace() != $type->getNamespace()) {
                     if ($extends->getName() == $type->getName()) {

--- a/src/Php/ClassGenerator.php
+++ b/src/Php/ClassGenerator.php
@@ -373,20 +373,11 @@ class ClassGenerator
                 $this->handleValueMethod($class, $p, $extends);
             } else {
 
-                //zend code ^3.0.3 wants FQCNs and resolves the short name based on provided use statements
-                //https://github.com/zendframework/zend-code/commit/4a6f4ab33480923ac6553ded903c97de168f37fe
-                //TypeGenerator is new to v3
-                if(class_exists('\Zend\Code\Generator\TypeGenerator')) {
-                    $class->setExtendedClass($extends->getFullName());
-                } else {
-                    //v2 simply used the string that was passed directly
-                    $class->setExtendedClass($extends->getName());
-                }
+                $class->setExtendedClass($extends->getFullName());
 
                 if ($extends->getNamespace() != $type->getNamespace()) {
                     if ($extends->getName() == $type->getName()) {
                         $class->addUse($type->getExtends()->getFullName(), $extends->getName() . "Base");
-                        $class->setExtendedClass($extends->getName() . "Base");
                     } else {
                         $class->addUse($extends->getFullName());
                     }

--- a/src/Php/ClassGenerator.php
+++ b/src/Php/ClassGenerator.php
@@ -373,7 +373,15 @@ class ClassGenerator
                 $this->handleValueMethod($class, $p, $extends);
             } else {
 
-                $class->setExtendedClass($extends->getFullName());
+                //zend code ^3.0.3 wants FQCNs and resolves the short name based on provided use statements
+                //https://github.com/zendframework/zend-code/commit/4a6f4ab33480923ac6553ded903c97de168f37fe
+                //TypeGenerator is new to v3
+                if(class_exists('\Zend\Code\Generator\TypeGenerator')) {
+                    $class->setExtendedClass($extends->getFullName());
+                } else {
+                    //v2 simply used the string that was passed directly
+                    $class->setExtendedClass($extends->getName());
+                }
 
                 if ($extends->getNamespace() != $type->getNamespace()) {
                     if ($extends->getName() == $type->getName()) {

--- a/src/Php/ClassGenerator.php
+++ b/src/Php/ClassGenerator.php
@@ -36,19 +36,7 @@ class ClassGenerator
 
         return true;
     }
-/*
-    private function isNativeType(PHPClass $class)
-    {
-        return !$class->getNamespace() && in_array($class->getName(), [
-            'string',
-            'int',
-            'float',
-            'bool',
-            'array',
-            'callable'
-        ]);
-    }
-*/
+
     private function handleValueMethod(Generator\ClassGenerator $generator, PHPProperty $prop, PHPClass $class, $all = true)
     {
         $type = $prop->getType();

--- a/src/Php/ClassGenerator.php
+++ b/src/Php/ClassGenerator.php
@@ -36,27 +36,26 @@ class ClassGenerator
 
         return true;
     }
-
+/*
     private function isNativeType(PHPClass $class)
     {
         return !$class->getNamespace() && in_array($class->getName(), [
             'string',
             'int',
             'float',
-            'integer',
-            'boolean',
+            'bool',
             'array',
             'callable'
         ]);
     }
-
+*/
     private function handleValueMethod(Generator\ClassGenerator $generator, PHPProperty $prop, PHPClass $class, $all = true)
     {
         $type = $prop->getType();
 
         $docblock = new DocBlockGenerator('Construct');
         $docblock->setWordWrap(false);
-        $paramTag = new ParamTag("value", "mixed");
+        $paramTag = new ParamTag("value");
         $paramTag->setTypes(($type ? $type->getPhpType() : "mixed"));
 
         $docblock->setTag($paramTag);
@@ -75,7 +74,7 @@ class ClassGenerator
 
         $docblock = new DocBlockGenerator('Gets or sets the inner value');
         $docblock->setWordWrap(false);
-        $paramTag = new ParamTag("value", "mixed");
+        $paramTag = new ParamTag("value");
         if ($type && $type instanceof PHPClassOf) {
             $paramTag->setTypes($type->getArg()->getType()->getPhpType() . "[]");
         } elseif ($type) {
@@ -192,12 +191,12 @@ class ClassGenerator
                 $docblock->setLongDescription($prop->getDoc());
             }
 
-            $patramTag = new ParamTag("index", "scalar");
+            $patramTag = new ParamTag("index", "int|string");
             $docblock->setTag($patramTag);
 
-            $docblock->setTag(new ReturnTag("boolean"));
+            $docblock->setTag(new ReturnTag("bool"));
 
-            $paramIndex = new ParameterGenerator("index", "mixed");
+            $paramIndex = new ParameterGenerator("index");
 
             $method = new MethodGenerator("isset" . Inflector::classify($prop->getName()), [$paramIndex]);
             $method->setDocBlock($docblock);
@@ -211,9 +210,9 @@ class ClassGenerator
                 $docblock->setLongDescription($prop->getDoc());
             }
 
-            $patramTag = new ParamTag("index", "scalar");
+            $patramTag = new ParamTag("index", "int|string");
             $docblock->setTag($patramTag);
-            $paramIndex = new ParameterGenerator("index", "mixed");
+            $paramIndex = new ParameterGenerator("index");
 
             $docblock->setTag(new ReturnTag("void"));
 

--- a/src/Php/PathGenerator/Psr4PathGenerator.php
+++ b/src/Php/PathGenerator/Psr4PathGenerator.php
@@ -14,8 +14,9 @@ class Psr4PathGenerator extends Psr4PathGeneratorBase implements PathGenerator
             if (strpos(trim($php->getNamespaceName()) . "\\", $namespace) === 0) {
                 $d = strtr(substr($php->getNamespaceName(), strlen($namespace)), "\\", "/");
                 $dir = rtrim($dir, "/") . "/" . $d;
-                if (!is_dir($dir) && !mkdir($dir, 0777, true)) {
-                    throw new PathGeneratorException("Can't create the '$dir' directory");
+                if (!is_dir($dir) && !@mkdir($dir, 0777, true)) {
+                    $error = error_get_last();
+                    throw new PathGeneratorException("Can't create the '$dir' directory: '{$error['message']}'");
                 }
 
                 return rtrim($dir, "/") . "/" . $php->getName() . ".php";

--- a/src/Php/PhpConverter.php
+++ b/src/Php/PhpConverter.php
@@ -221,7 +221,7 @@ class PhpConverter extends AbstractConverter
     /**
      *
      * @param Type $type
-     * @param boolean $force
+     * @param bool $force
      * @param bool $skip
      * @return PHPClass
      * @throws Exception
@@ -399,7 +399,7 @@ class PhpConverter extends AbstractConverter
      * @param PHPClass $class
      * @param Schema $schema
      * @param Element $element
-     * @param boolean $arrayize
+     * @param bool $arrayize
      * @return \GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPProperty
      */
     private function visitElement(PHPClass $class, Schema $schema, ElementSingle $element, $arrayize = true)

--- a/src/Php/Structure/PHPClass.php
+++ b/src/Php/Structure/PHPClass.php
@@ -56,11 +56,11 @@ class PHPClass
             'string',
             'int',
             'float',
-            'integer',
-            'boolean',
+            'bool',
             'array',
-            'mixed',
-            'callable'
+            'callable',
+
+            'mixed' //todo this is not a php type but it's needed for now to allow mixed return tags
         ]);
     }
 
@@ -167,7 +167,7 @@ class PHPClass
     /**
      *
      * @param string $name
-     * @return boolean
+     * @return bool
      */
     public function hasProperty($name)
     {
@@ -245,7 +245,7 @@ class PHPClass
 
     /**
      *
-     * @var boolean
+     * @var bool
      */
     protected $abstract;
 
@@ -282,7 +282,7 @@ class PHPClass
 
     public function setAbstract($abstract)
     {
-        $this->abstract = (boolean)$abstract;
+        $this->abstract = (bool)$abstract;
         return $this;
     }
 }

--- a/src/Writer/PHPClassWriter.php
+++ b/src/Writer/PHPClassWriter.php
@@ -1,6 +1,7 @@
 <?php
 namespace GoetasWebservices\Xsd\XsdToPhp\Writer;
 
+use GoetasWebservices\Xsd\XsdToPhp\Php\ClassGenerator;
 use GoetasWebservices\Xsd\XsdToPhp\Php\PathGenerator\PathGenerator;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
@@ -20,6 +21,9 @@ class PHPClassWriter implements LoggerAwareInterface
         $this->logger = $logger ?: new NullLogger();
     }
 
+    /**
+     * @param ClassGenerator[] $items
+     */
     public function write(array $items)
     {
         foreach ($items as $item) {

--- a/src/Writer/PHPWriter.php
+++ b/src/Writer/PHPWriter.php
@@ -22,10 +22,15 @@ class PHPWriter extends Writer implements LoggerAwareInterface
         $this->logger = $logger ?: new NullLogger();
     }
 
+    /**
+     * @param PHPClass[] $items
+     */
     public function write(array $items)
     {
-        return $this->classWriter->write(array_filter(array_map(function (PHPClass $item) {
-            return $this->generator->generate($item);
-        }, $items)));
+        while($item = array_pop($items)) {
+            if($generator = $this->generator->generate($item)) {
+                $this->classWriter->write([$generator]);
+            }
+        }
     }
 }

--- a/tests/AbstractGenerator.php
+++ b/tests/AbstractGenerator.php
@@ -34,7 +34,7 @@ abstract class AbstractGenerator
         $this->phpDir = "$tmp/php";
         $this->jmsDir = "$tmp/jms";
 
-        $this->namingStrategy = new VeryShortNamingStrategy();
+        $this->namingStrategy = defined('PHP_WINDOWS_VERSION_BUILD') ? new VeryShortNamingStrategy() : new ShortNamingStrategy();
 
         $this->loader = new ClassLoader();
         foreach ($this->targetNs as $phpNs) {

--- a/tests/AbstractGenerator.php
+++ b/tests/AbstractGenerator.php
@@ -34,7 +34,7 @@ abstract class AbstractGenerator
         $this->phpDir = "$tmp/php";
         $this->jmsDir = "$tmp/jms";
 
-        $this->namingStrategy = new ShortNamingStrategy();
+        $this->namingStrategy = new VeryShortNamingStrategy();
 
         $this->loader = new ClassLoader();
         foreach ($this->targetNs as $phpNs) {

--- a/tests/Converter/JMS/Xsd2JmsBase.php
+++ b/tests/Converter/JMS/Xsd2JmsBase.php
@@ -49,8 +49,8 @@ abstract class Xsd2JmsBase extends \PHPUnit_Framework_TestCase
         return [
             ['xs:string', 'string'],
             ['xs:decimal', 'float'],
-            ['xs:int', 'integer'],
-            ['xs:integer', 'integer'],
+            ['xs:int', 'int'],
+            ['xs:integer', 'int'],
         ];
     }
 }

--- a/tests/Generator.php
+++ b/tests/Generator.php
@@ -9,11 +9,9 @@ class Generator extends AbstractGenerator
     public function generate(array $schemas)
     {
         $this->cleanDirectories();
-
-        list($php, $jms) = $this->getData($schemas);
-
-        $this->writeJMS($jms);
-        $this->writePHP($php);
+        
+        $this->writeJMS($this->generateJMSFiles($schemas));
+        $this->writePHP($this->generatePHPFiles($schemas));
     }
 
     public function getData(array $schemas)

--- a/tests/PHP/PHPConversionTest.php
+++ b/tests/PHP/PHPConversionTest.php
@@ -145,6 +145,10 @@ class PHPConversionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($codegen->hasMethod('getId'));
         $this->assertTrue($codegen->hasMethod('setId'));
+
+        $this->assertNull($codegen->getMethod('issetId')->getParameters()['index']->getType());
+        $this->assertNull($codegen->getMethod('issetId')->getParameters()['index']->getType());
+
     }
 
     public function testNestedMulteplicity()

--- a/tests/VeryShortNamingStrategy.php
+++ b/tests/VeryShortNamingStrategy.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace GoetasWebservices\Xsd\XsdToPhp\Tests;
+
+use Doctrine\Common\Inflector\Inflector;
+use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
+use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
+
+/**
+ * The OTA psr4 class paths can exceed windows max dir length
+ */
+class VeryShortNamingStrategy extends ShortNamingStrategy
+{
+    /**
+     * Suffix with T instead of Type
+     * @param Type $type
+     * @return string
+     */
+    public function getTypeName(Type $type)
+    {
+        if ($name = $this->classify($type->getName())) {
+            if (substr($name, -4) !== 'Type') {
+                $name .= "T";
+            } elseif (substr($name, -4) === 'Type') {
+                $name = substr($name, 0, -3);
+            }
+        }
+        return $name;
+    }
+
+    /**
+     * Suffix with A instead of AType
+     * @param Type $type
+     * @param string $parentName
+     * @return string
+     */
+    public function getAnonymousTypeName(Type $type, $parentName)
+    {
+        return $this->classify($parentName) . "A";
+    }
+
+    private function classify($name)
+    {
+        return Inflector::classify(str_replace(".", " ", $name));
+    }
+}

--- a/tests/VeryShortNamingStrategy.php
+++ b/tests/VeryShortNamingStrategy.php
@@ -12,33 +12,40 @@ use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
 class VeryShortNamingStrategy extends ShortNamingStrategy
 {
     /**
-     * Suffix with T instead of Type
+     * Suffix with 'T' instead of 'Type'
      * @param Type $type
      * @return string
      */
     public function getTypeName(Type $type)
     {
-        if ($name = $this->classify($type->getName())) {
-            if (substr($name, -4) !== 'Type') {
-                $name .= "T";
-            } elseif (substr($name, -4) === 'Type') {
-                $name = substr($name, 0, -3);
-            }
+        $name = $this->classify($type->getName());
+
+        if ($name && substr($name, -4) !== 'Type') {
+            return $name . 'T';
         }
+
+        if (substr($name, -4) === 'Type') {
+            return substr($name, 0, -3);
+        }
+
         return $name;
     }
 
     /**
-     * Suffix with A instead of AType
+     * Suffix with 'A' instead of 'AType'
      * @param Type $type
      * @param string $parentName
      * @return string
      */
     public function getAnonymousTypeName(Type $type, $parentName)
     {
-        return $this->classify($parentName) . "A";
+        return $this->classify($parentName) . 'A';
     }
 
+    /**
+     * @param string $name
+     * @return string
+     */
     private function classify($name)
     {
         return Inflector::classify(str_replace(".", " ", $name));


### PR DESCRIPTION
These changes replace various native PHP type aliases with the formal PHP types since `zend-code ^3.0` was considering the aliases as actual classes in parameter hints (eg `boolean -> \boolean`). 

References to `mixed` removed when used in parameter hints but remain in docblocks. 

`scalar` was replaced with `int|string` in doc blocks since its not a valid PHP type or pseudo-type. `is_scalar()` defines a `scalar` as `int|string|float|bool` but it was used exclusively in an array key context so `float|bool` are converted to `int` anyways. 