### PR TITLE
Better detection of simple type in parent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@
 /.settings
 /.idea
 composer.lock
-vendor/
+vendor
+/php-cs-fixer
+/.php_cs.cache
 

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,18 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in([__DIR__. '/src', __DIR__. '/tests'])
+    ->exclude('tmp')
+
+;
+
+return PhpCsFixer\Config::create()
+    ->setRules(array(
+        '@Symfony' => true,
+        'concat_space' => array('spacing' => 'one'),
+        'phpdoc_annotation_without_dot' => false,
+        'yoda_style' => false,
+        'array_indentation' => true,
+    ))
+    ->setFinder($finder)
+;

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "0.2-dev"
+      "dev-master": "0.4-dev"
     }
   },
   "bin": [

--- a/src/AbstractConverter.php
+++ b/src/AbstractConverter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp;
 
 use GoetasWebservices\XML\XSDReader\Schema\Element\ElementSingle;
@@ -16,26 +17,26 @@ abstract class AbstractConverter
 {
     use LoggerAwareTrait;
 
-    protected $baseSchemas = array(
+    protected $baseSchemas = [
         'http://www.w3.org/2001/XMLSchema',
-        'http://www.w3.org/XML/1998/namespace'
-    );
+        'http://www.w3.org/XML/1998/namespace',
+    ];
 
-    protected $namespaces = array(
+    protected $namespaces = [
         'http://www.w3.org/2001/XMLSchema' => '',
-        'http://www.w3.org/XML/1998/namespace' => ''
-    );
+        'http://www.w3.org/XML/1998/namespace' => '',
+    ];
 
     /**
      * @var \GoetasWebservices\Xsd\XsdToPhp\Naming\NamingStrategy
      */
     private $namingStrategy;
 
-    public abstract function convert(array $schemas);
+    abstract public function convert(array $schemas);
 
-    protected $typeAliases = array();
+    protected $typeAliases = [];
 
-    protected $aliasCache = array();
+    protected $aliasCache = [];
 
     public function addAliasMap($ns, $name, callable $handler)
     {
@@ -54,7 +55,7 @@ abstract class AbstractConverter
     {
         $schema = $schemapos ?: $type->getSchema();
 
-        $cid = $schema->getTargetNamespace() . "|" . $type->getName();
+        $cid = $schema->getTargetNamespace() . '|' . $type->getName();
         if (isset($this->aliasCache[$cid])) {
             return $this->aliasCache[$cid];
         }
@@ -68,115 +69,115 @@ abstract class AbstractConverter
         $this->namingStrategy = $namingStrategy;
         $this->logger = $logger ?: new NullLogger();
 
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "gYearMonth", function (Type $type) {
-            return "int";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'gYearMonth', function (Type $type) {
+            return 'int';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "gMonthDay", function (Type $type) {
-            return "int";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'gMonthDay', function (Type $type) {
+            return 'int';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "gMonth", function (Type $type) {
-            return "int";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'gMonth', function (Type $type) {
+            return 'int';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "gYear", function (Type $type) {
-            return "int";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'gYear', function (Type $type) {
+            return 'int';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "NMTOKEN", function (Type $type) {
-            return "string";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'NMTOKEN', function (Type $type) {
+            return 'string';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "NMTOKENS", function (Type $type) {
-            return "string";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'NMTOKENS', function (Type $type) {
+            return 'string';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "QName", function (Type $type) {
-            return "string";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'QName', function (Type $type) {
+            return 'string';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "NCName", function (Type $type) {
-            return "string";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'NCName', function (Type $type) {
+            return 'string';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "decimal", function (Type $type) {
-            return "float";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'decimal', function (Type $type) {
+            return 'float';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "float", function (Type $type) {
-            return "float";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'float', function (Type $type) {
+            return 'float';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "double", function (Type $type) {
-            return "float";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'double', function (Type $type) {
+            return 'float';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "string", function (Type $type) {
-            return "string";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'string', function (Type $type) {
+            return 'string';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "normalizedString", function (Type $type) {
-            return "string";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'normalizedString', function (Type $type) {
+            return 'string';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "integer", function (Type $type) {
-            return "int";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'integer', function (Type $type) {
+            return 'int';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "int", function (Type $type) {
-            return "int";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'int', function (Type $type) {
+            return 'int';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "unsignedInt", function (Type $type) {
-            return "int";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'unsignedInt', function (Type $type) {
+            return 'int';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "negativeInteger", function (Type $type) {
-            return "int";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'negativeInteger', function (Type $type) {
+            return 'int';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "positiveInteger", function (Type $type) {
-            return "int";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'positiveInteger', function (Type $type) {
+            return 'int';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "nonNegativeInteger", function (Type $type) {
-            return "int";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'nonNegativeInteger', function (Type $type) {
+            return 'int';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "nonPositiveInteger", function (Type $type) {
-            return "int";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'nonPositiveInteger', function (Type $type) {
+            return 'int';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "long", function (Type $type) {
-            return "int";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'long', function (Type $type) {
+            return 'int';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "unsignedLong", function (Type $type) {
-            return "int";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'unsignedLong', function (Type $type) {
+            return 'int';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "short", function (Type $type) {
-            return "int";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'short', function (Type $type) {
+            return 'int';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "boolean", function (Type $type) {
-            return "bool";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'boolean', function (Type $type) {
+            return 'bool';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "nonNegativeInteger", function (Type $type) {
-            return "int";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'nonNegativeInteger', function (Type $type) {
+            return 'int';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "positiveInteger", function (Type $type) {
-            return "int";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'positiveInteger', function (Type $type) {
+            return 'int';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "language", function (Type $type) {
-            return "string";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'language', function (Type $type) {
+            return 'string';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "token", function (Type $type) {
-            return "string";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'token', function (Type $type) {
+            return 'string';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "anyURI", function (Type $type) {
-            return "string";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'anyURI', function (Type $type) {
+            return 'string';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "byte", function (Type $type) {
-            return "string";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'byte', function (Type $type) {
+            return 'string';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "duration", function (Type $type) {
-            return "DateInterval";
-        });
-
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "ID", function (Type $type) {
-            return "string";
-        });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "IDREF", function (Type $type) {
-            return "string";
-        });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "IDREFS", function (Type $type) {
-            return "string";
-        });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "Name", function (Type $type) {
-            return "string";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'duration', function (Type $type) {
+            return 'DateInterval';
         });
 
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "NCName", function (Type $type) {
-            return "string";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'ID', function (Type $type) {
+            return 'string';
+        });
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'IDREF', function (Type $type) {
+            return 'string';
+        });
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'IDREFS', function (Type $type) {
+            return 'string';
+        });
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'Name', function (Type $type) {
+            return 'string';
+        });
+
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'NCName', function (Type $type) {
+            return 'string';
         });
     }
 
@@ -192,16 +193,16 @@ abstract class AbstractConverter
     {
         $this->logger->info("Added ns mapping $ns, $phpNamespace");
         $this->namespaces[$ns] = $phpNamespace;
+
         return $this;
     }
 
     protected function cleanName($name)
     {
-        return preg_replace("/<.*>/", "", $name);
+        return preg_replace('/<.*>/', '', $name);
     }
 
     /**
-     * @param Type $type
      * @return \GoetasWebservices\XML\XSDReader\Schema\Type\Type|null
      */
     protected function isArrayType(Type $type)
@@ -210,7 +211,7 @@ abstract class AbstractConverter
             if ($type->getList()) {
                 return $type->getList();
             } elseif (($rst = $type->getRestriction()) && $rst->getBase() instanceof SimpleType) {
-              return $this->isArrayType($rst->getBase());
+                return $this->isArrayType($rst->getBase());
             }
         } elseif ($type instanceof ComplexTypeSimpleContent) {
             if ($ext = $type->getExtension()) {
@@ -222,19 +223,20 @@ abstract class AbstractConverter
     }
 
     /**
-     * @param Type $type
      * @return \GoetasWebservices\XML\XSDReader\Schema\Element\ElementSingle|null
      */
     protected function isArrayNestedElement(Type $type)
     {
         if ($type instanceof ComplexType && !$type->getParent() && !$type->getAttributes() && count($type->getElements()) === 1) {
             $elements = $type->getElements();
+
             return $this->isArrayElement(reset($elements));
         }
     }
 
     /**
      * @param mixed $element
+     *
      * @return \GoetasWebservices\XML\XSDReader\Schema\Element\ElementSingle|null
      */
     protected function isArrayElement($element)
@@ -248,5 +250,4 @@ abstract class AbstractConverter
     {
         return $this->namespaces;
     }
-
 }

--- a/src/Command/Convert.php
+++ b/src/Command/Convert.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Command;
 
 use Symfony\Component\Config\FileLocator;
@@ -26,21 +27,19 @@ class Convert extends Command
     }
 
     /**
-     *
      * @see Console\Command\Command
      */
     protected function configure()
     {
         $this->setName('convert');
-        $this->setDescription("Convert a XSD file into PHP classes and JMS serializer metadata files");
-        $this->setDefinition(array(
+        $this->setDescription('Convert a XSD file into PHP classes and JMS serializer metadata files');
+        $this->setDefinition([
             new InputArgument('config', InputArgument::REQUIRED, 'Where is located your XSD definitions'),
             new InputArgument('src', InputArgument::REQUIRED | InputArgument::IS_ARRAY, 'Where is located your XSD definitions'),
-        ));
+        ]);
     }
 
     /**
-     *
      * @see Console\Command\Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -56,7 +55,6 @@ class Convert extends Command
         $configs = $this->container->getParameter('goetas_webservices.xsd2php.config');
 
         foreach (['php', 'jms', 'validation'] as $type) {
-
             if ($type === 'validation' && empty($configs['destinations_' . $type])) {
                 continue;
             }
@@ -66,6 +64,7 @@ class Convert extends Command
             $writer = $this->container->get('goetas_webservices.xsd2php.writer.' . $type);
             $writer->write($items);
         }
+
         return count($items) ? 0 : 255;
     }
 
@@ -75,10 +74,9 @@ class Convert extends Command
         $yaml = new YamlFileLoader($this->container, $locator);
         $xml = new XmlFileLoader($this->container, $locator);
 
-        $delegatingLoader = new DelegatingLoader(new LoaderResolver(array($yaml, $xml)));
+        $delegatingLoader = new DelegatingLoader(new LoaderResolver([$yaml, $xml]));
         $delegatingLoader->load($configFile);
 
         $this->container->compile();
-
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -71,6 +72,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end();
+
         return $treeBuilder;
     }
 }

--- a/src/DependencyInjection/Xsd2PhpExtension.php
+++ b/src/DependencyInjection/Xsd2PhpExtension.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
@@ -8,7 +9,6 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 class Xsd2PhpExtension extends Extension
 {
-
     public function load(array $configs, ContainerBuilder $container)
     {
         $xml = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
@@ -22,7 +22,6 @@ class Xsd2PhpExtension extends Extension
 
         $definition = $container->getDefinition('goetas_webservices.xsd2php.naming_convention.' . $config['naming_strategy']);
         $container->setDefinition('goetas_webservices.xsd2php.naming_convention', $definition);
-
 
         $schemaReader = $container->getDefinition('goetas_webservices.xsd2php.schema_reader');
         foreach ($config['known_locations'] as $remote => $local) {

--- a/src/Jms/PathGenerator/PathGenerator.php
+++ b/src/Jms/PathGenerator/PathGenerator.php
@@ -1,7 +1,6 @@
 <?php
-namespace GoetasWebservices\Xsd\XsdToPhp\Jms\PathGenerator;
 
-use GoetasWebservices\Xsd\XsdToPhp\PathGenerator\PathGenerator as PathGeneratorBase;
+namespace GoetasWebservices\Xsd\XsdToPhp\Jms\PathGenerator;
 
 interface PathGenerator
 {

--- a/src/Jms/PathGenerator/Psr4PathGenerator.php
+++ b/src/Jms/PathGenerator/Psr4PathGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Jms\PathGenerator;
 
 use GoetasWebservices\Xsd\XsdToPhp\PathGenerator\PathGeneratorException;
@@ -11,18 +12,17 @@ class Psr4PathGenerator extends Psr4PathGeneratorBase implements PathGenerator
         $ns = key($yaml);
 
         foreach ($this->namespaces as $namespace => $dir) {
-
             $pos = strpos($ns, $namespace);
 
             if ($pos === 0) {
                 if (!is_dir($dir) && !mkdir($dir, 0777, true)) {
                     throw new PathGeneratorException("Can't create the folder '$dir'");
                 }
-                $f = trim(strtr(substr($ns, strlen($namespace)), "\\/", ".."), ".");
-                return $dir . "/" . $f . ".yml";
+                $f = trim(strtr(substr($ns, strlen($namespace)), '\\/', '..'), '.');
+
+                return $dir . '/' . $f . '.yml';
             }
         }
         throw new PathGeneratorException("Unable to determine location to save JMS metadata for class '$ns'");
     }
 }
-

--- a/src/Jms/YamlConverter.php
+++ b/src/Jms/YamlConverter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Jms;
 
 use Doctrine\Common\Inflector\Inflector;
@@ -25,12 +26,10 @@ use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass;
 
 class YamlConverter extends AbstractConverter
 {
-
     protected $useCdata = true;
 
     public function __construct(NamingStrategy $namingStrategy)
     {
-
         parent::__construct($namingStrategy);
 
         $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'dateTime', function (Type $type) {
@@ -39,11 +38,11 @@ class YamlConverter extends AbstractConverter
         $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'time', function (Type $type) {
             return "GoetasWebservices\Xsd\XsdToPhp\XMLSchema\Time";
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "date", function (Type $type) {
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'date', function (Type $type) {
             return "GoetasWebservices\Xsd\XsdToPhp\XMLSchema\Date";
         });
 
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "base64Binary", function (Type $type) {
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'base64Binary', function (Type $type) {
             return "GoetasWebservices\Xsd\XsdToPhp\XMLSchema\Base64Binary";
         });
     }
@@ -52,6 +51,7 @@ class YamlConverter extends AbstractConverter
     {
         $this->logger->info("Set useCdata $value");
         $this->useCdata = $value;
+
         return $this;
     }
 
@@ -59,17 +59,18 @@ class YamlConverter extends AbstractConverter
 
     public function convert(array $schemas)
     {
-        $visited = array();
-        $this->classes = array();
+        $visited = [];
+        $this->classes = [];
         foreach ($schemas as $schema) {
             $this->navigate($schema, $visited);
         }
+
         return $this->getTypes();
     }
 
     private function flattAttributes(AttributeContainer $container)
     {
-        $items = array();
+        $items = [];
         foreach ($container->getAttributes() as $attr) {
             if ($attr instanceof AttributeContainer) {
                 $items = array_merge($items, $this->flattAttributes($attr));
@@ -77,12 +78,13 @@ class YamlConverter extends AbstractConverter
                 $items[] = $attr;
             }
         }
+
         return $items;
     }
 
     private function flattElements(ElementContainer $container)
     {
-        $items = array();
+        $items = [];
         foreach ($container->getElements() as $attr) {
             if ($attr instanceof ElementContainer) {
                 $items = array_merge($items, $this->flattElements($attr));
@@ -90,11 +92,11 @@ class YamlConverter extends AbstractConverter
                 $items[] = $attr;
             }
         }
+
         return $items;
     }
 
     /**
-     *
      * @return PHPClass[]
      */
     public function getTypes()
@@ -103,13 +105,13 @@ class YamlConverter extends AbstractConverter
             return strcmp(key($a), key($b));
         });
 
-        $ret = array();
+        $ret = [];
 
         foreach ($this->classes as $definition) {
-            $classname = key($definition["class"]);
-            if (strpos($classname, '\\') !== false && (!isset($definition["skip"]) || !$definition["skip"])) {
-                unset($definition["class"][$classname]["extends"]);
-                $ret[$classname] = $definition["class"];
+            $classname = key($definition['class']);
+            if (strpos($classname, '\\') !== false && (!isset($definition['skip']) || !$definition['skip'])) {
+                unset($definition['class'][$classname]['extends']);
+                $ret[$classname] = $definition['class'];
             }
         }
 
@@ -153,21 +155,21 @@ class YamlConverter extends AbstractConverter
     public function &visitElementDef(Schema $schema, ElementDef $element)
     {
         if (!isset($this->classes[spl_object_hash($element)])) {
-            $className = $this->findPHPNamespace($element) . "\\" . $this->getNamingStrategy()->getItemName($element);
-            $class = array();
-            $data = array();
+            $className = $this->findPHPNamespace($element) . '\\' . $this->getNamingStrategy()->getItemName($element);
+            $class = [];
+            $data = [];
             $ns = $className;
             $class[$ns] = &$data;
-            $data["xml_root_name"] = $element->getName();
+            $data['xml_root_name'] = $element->getName();
 
             if ($schema->getTargetNamespace()) {
-                $data["xml_root_namespace"] = $schema->getTargetNamespace();
+                $data['xml_root_namespace'] = $schema->getTargetNamespace();
 
                 if (!$schema->getElementsQualification() && !($element instanceof Element && $element->isQualified())) {
-                    $data["xml_root_name"] = "ns-" . substr(sha1($data["xml_root_namespace"]), 0, 8) . ":" . $element->getName();
+                    $data['xml_root_name'] = 'ns-' . substr(sha1($data['xml_root_namespace']), 0, 8) . ':' . $element->getName();
                 }
             }
-            $this->classes[spl_object_hash($element)]["class"] = &$class;
+            $this->classes[spl_object_hash($element)]['class'] = &$class;
 
             $type = $element->getType();
             if (!$type->getName()) {
@@ -175,12 +177,14 @@ class YamlConverter extends AbstractConverter
             } else {
                 $visitedTypeClass = $this->visitType($type);
             }
-            $this->classes[spl_object_hash($element)]["skip"] = in_array($element->getSchema()->getTargetNamespace(), $this->baseSchemas, true)
+
+            $data['extends'] = $visitedTypeClass;
+            $this->classes[spl_object_hash($element)]['skip'] = in_array($element->getSchema()->getTargetNamespace(), $this->baseSchemas, true)
                 || $this->getTypeAlias($type, $type->getSchema())
                 || $this->getPropertyInHierarchy($visitedTypeClass, '__value');
         }
 
-        return $this->classes[spl_object_hash($element)]["class"];
+        return $this->classes[spl_object_hash($element)]['class'];
     }
 
     private function findPHPNamespace(SchemaItem $item)
@@ -190,9 +194,9 @@ class YamlConverter extends AbstractConverter
         if (!isset($this->namespaces[$schema->getTargetNamespace()])) {
             throw new Exception(sprintf("Can't find a PHP namespace to '%s' namespace", $schema->getTargetNamespace()));
         }
+
         return $this->namespaces[$schema->getTargetNamespace()];
     }
-
 
     private function findPHPName(Type $type)
     {
@@ -205,87 +209,90 @@ class YamlConverter extends AbstractConverter
         $ns = $this->findPHPNamespace($type);
         $name = $this->getNamingStrategy()->getTypeName($type);
 
-        return $ns . "\\" . $name;
+        return $ns . '\\' . $name;
     }
-
 
     public function &visitType(Type $type, $force = false)
     {
         $skip = in_array($type->getSchema()->getTargetNamespace(), $this->baseSchemas, true);
 
         if (!isset($this->classes[spl_object_hash($type)])) {
-
-            $this->classes[spl_object_hash($type)]["skip"] = $skip;
+            $this->classes[spl_object_hash($type)]['skip'] = $skip;
             if ($alias = $this->getTypeAlias($type)) {
-                $class = array();
-                $class[$alias] = array();
+                $class = [];
+                $class[$alias] = [];
 
-                $this->classes[spl_object_hash($type)]["class"] = &$class;
-                $this->classes[spl_object_hash($type)]["skip"] = true;
+                $this->classes[spl_object_hash($type)]['class'] = &$class;
+                $this->classes[spl_object_hash($type)]['skip'] = true;
+
                 return $class;
             }
 
             $className = $this->findPHPName($type);
 
-            $class = array();
-            $data = array();
+            $class = [];
+            $data = [];
 
             $class[$className] = &$data;
 
-            $this->classes[spl_object_hash($type)]["class"] = &$class;
+            $this->classes[spl_object_hash($type)]['class'] = &$class;
 
             $this->visitTypeBase($class, $data, $type, $type->getName());
 
             if ($type instanceof SimpleType || $this->isArrayType($type)) {
-                $this->classes[spl_object_hash($type)]["skip"] = true;
+                $this->classes[spl_object_hash($type)]['skip'] = true;
+
                 return $class;
             }
 
             if (!$force && ($this->isArrayType($type) || $this->isArrayNestedElement($type))) {
-                $this->classes[spl_object_hash($type)]["skip"] = true;
+                $this->classes[spl_object_hash($type)]['skip'] = true;
+
                 return $class;
             }
         } elseif ($force) {
             if (!($type instanceof SimpleType) && !$this->getTypeAlias($type)) {
-                $this->classes[spl_object_hash($type)]["skip"] = $skip;
+                $this->classes[spl_object_hash($type)]['skip'] = $skip;
             }
         }
-        return $this->classes[spl_object_hash($type)]["class"];
+
+        return $this->classes[spl_object_hash($type)]['class'];
     }
 
     /**
-     * @param Type $type
      * @param string $parentName
      * @param string $parentClass
+     *
      * @return array
      */
     private function &visitTypeAnonymous(Type $type, $parentName, $parentClass)
     {
         if (!isset($this->classes[spl_object_hash($type)])) {
-            $class = array();
-            $data = array();
+            $class = [];
+            $data = [];
 
             $name = $this->getNamingStrategy()->getAnonymousTypeName($type, $parentName);
 
-            $class[$parentClass . "\\" . $name] = &$data;
+            $class[$parentClass . '\\' . $name] = &$data;
 
             $this->visitTypeBase($class, $data, $type, $parentName);
-            $this->classes[spl_object_hash($type)]["class"] = &$class;
+            $this->classes[spl_object_hash($type)]['class'] = &$class;
             if ($type instanceof SimpleType) {
-                $this->classes[spl_object_hash($type)]["skip"] = true;
+                $this->classes[spl_object_hash($type)]['skip'] = true;
             }
         }
-        return $this->classes[spl_object_hash($type)]["class"];
+
+        return $this->classes[spl_object_hash($type)]['class'];
     }
 
     private function visitComplexType(&$class, &$data, ComplexType $type)
     {
         $schema = $type->getSchema();
-        if (!isset($data["properties"])) {
-            $data["properties"] = array();
+        if (!isset($data['properties'])) {
+            $data['properties'] = [];
         }
         foreach ($this->flattElements($type) as $element) {
-            $data["properties"][$this->getNamingStrategy()->getPropertyName($element)] = $this->visitElement($class, $schema, $element);
+            $data['properties'][$this->getNamingStrategy()->getPropertyName($element)] = $this->visitElement($class, $schema, $element);
         }
     }
 
@@ -315,35 +322,33 @@ class YamlConverter extends AbstractConverter
         }
 
         $schema = $type->getSchema();
-        if (!isset($data["properties"])) {
-            $data["properties"] = array();
+        if (!isset($data['properties'])) {
+            $data['properties'] = [];
         }
         foreach ($this->flattAttributes($type) as $attr) {
-            $data["properties"][$this->getNamingStrategy()->getPropertyName($attr)] = $this->visitAttribute($class, $schema, $attr);
+            $data['properties'][$this->getNamingStrategy()->getPropertyName($attr)] = $this->visitAttribute($class, $schema, $attr);
         }
     }
 
     protected function &handleClassExtension(&$class, &$data, Type $type, $parentName)
     {
-        $property = array();
+        $property = [];
         if ($alias = $this->getTypeAlias($type)) {
-
-            $property = array();
-            $property["expose"] = true;
-            $property["xml_value"] = true;
-            $property["access_type"] = "public_method";
-            $property["accessor"]["getter"] = "value";
-            $property["accessor"]["setter"] = "value";
-            $property["type"] = $alias;
+            $property = [];
+            $property['expose'] = true;
+            $property['xml_value'] = true;
+            $property['access_type'] = 'public_method';
+            $property['accessor']['getter'] = 'value';
+            $property['accessor']['setter'] = 'value';
+            $property['type'] = $alias;
             if (!$this->useCdata) {
-                $property["xml_element"]["cdata"] = $this->useCdata;
+                $property['xml_element']['cdata'] = $this->useCdata;
             }
 
-            $data["properties"]["__value"] = $property;
+            $data['properties']['__value'] = $property;
+
             return $property;
-
         } else {
-
             if (!$type->getName()) {
                 $extension = $this->visitTypeAnonymous($type, $parentName, key($class));
             } else {
@@ -351,7 +356,8 @@ class YamlConverter extends AbstractConverter
             }
 
             if ($prop = $this->getPropertyInHierarchy($extension, '__value')) {
-                $data["properties"]["__value"] = $prop;
+                $data['properties']['__value'] = $prop;
+
                 return $property;
             } else {
                 $data['extends'] = $extension;
@@ -363,30 +369,28 @@ class YamlConverter extends AbstractConverter
 
     protected function &visitAttribute(&$class, Schema $schema, AttributeItem $attribute)
     {
-        $property = array();
-        $property["expose"] = true;
-        $property["access_type"] = "public_method";
-        $property["serialized_name"] = $attribute->getName();
+        $property = [];
+        $property['expose'] = true;
+        $property['access_type'] = 'public_method';
+        $property['serialized_name'] = $attribute->getName();
 
-        $property["accessor"]["getter"] = "get" . Inflector::classify($this->getNamingStrategy()->getPropertyName($attribute));
-        $property["accessor"]["setter"] = "set" . Inflector::classify($this->getNamingStrategy()->getPropertyName($attribute));
+        $property['accessor']['getter'] = 'get' . Inflector::classify($this->getNamingStrategy()->getPropertyName($attribute));
+        $property['accessor']['setter'] = 'set' . Inflector::classify($this->getNamingStrategy()->getPropertyName($attribute));
 
-        $property["xml_attribute"] = true;
+        $property['xml_attribute'] = true;
 
         if ($alias = $this->getTypeAlias($attribute)) {
-            $property["type"] = $alias;
-
+            $property['type'] = $alias;
         } elseif ($itemOfArray = $this->isArrayType($attribute->getType())) {
-
             if ($valueProp = $this->typeHasValue($itemOfArray, $class, 'xx')) {
-                $property["type"] = "GoetasWebservices\Xsd\XsdToPhp\Jms\SimpleListOf<" . $valueProp . ">";
+                $property['type'] = "GoetasWebservices\Xsd\XsdToPhp\Jms\SimpleListOf<" . $valueProp . '>';
             } else {
-                $property["type"] = "GoetasWebservices\Xsd\XsdToPhp\Jms\SimpleListOf<" . $this->findPHPName($itemOfArray) . ">";
+                $property['type'] = "GoetasWebservices\Xsd\XsdToPhp\Jms\SimpleListOf<" . $this->findPHPName($itemOfArray) . '>';
             }
-
         } else {
-            $property["type"] = $this->findPHPClass($class, $attribute);
+            $property['type'] = $this->findPHPClass($class, $attribute);
         }
+
         return $property;
     }
 
@@ -428,12 +432,13 @@ class YamlConverter extends AbstractConverter
         return false;
     }
 
-
     public function getPropertyInHierarchy($class, $prop)
     {
         $props = reset($class);
 
-        if (isset($props['properties']) && count($props['properties'])>1) {
+        if (
+            (isset($props['properties']) && count($props['properties']) > 0 && !isset($props['properties'][$prop])) ||
+            (isset($props['properties']) && count($props['properties']) > 1)) {
             return false;
         }
 
@@ -447,9 +452,10 @@ class YamlConverter extends AbstractConverter
 
         return false;
     }
+
     /**
-     * @param Schema $schema
      * @param Element|ElementSingle $element
+     *
      * @return string|null
      */
     protected function getElementNamespace(Schema $schema, ElementItem $element)
@@ -459,41 +465,39 @@ class YamlConverter extends AbstractConverter
         ) {
             return $element->getSchema()->getTargetNamespace();
         }
+
         return null;
     }
 
     /**
-     *
      * @param PHPClass $class
-     * @param Schema $schema
-     * @param Element $element
-     * @param bool $arrayize
+     * @param Element  $element
+     * @param bool     $arrayize
+     *
      * @return \GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPProperty
      */
     protected function &visitElement(&$class, Schema $schema, ElementItem $element, $arrayize = true)
     {
-        $property = array();
-        $property["expose"] = true;
-        $property["access_type"] = "public_method";
-        $property["serialized_name"] = $element->getName();
+        $property = [];
+        $property['expose'] = true;
+        $property['access_type'] = 'public_method';
+        $property['serialized_name'] = $element->getName();
 
         if (!$this->useCdata) {
-            $property["xml_element"]["cdata"] = $this->useCdata;
+            $property['xml_element']['cdata'] = $this->useCdata;
         }
         $elementNamespace = $this->getElementNamespace($schema, $element);
         if ($elementNamespace) {
-            $property["xml_element"]["namespace"] = $elementNamespace;
+            $property['xml_element']['namespace'] = $elementNamespace;
         }
 
-        $property["accessor"]["getter"] = "get" . Inflector::classify($this->getNamingStrategy()->getPropertyName($element));
-        $property["accessor"]["setter"] = "set" . Inflector::classify($this->getNamingStrategy()->getPropertyName($element));
+        $property['accessor']['getter'] = 'get' . Inflector::classify($this->getNamingStrategy()->getPropertyName($element));
+        $property['accessor']['setter'] = 'set' . Inflector::classify($this->getNamingStrategy()->getPropertyName($element));
         $t = $element->getType();
 
         if ($arrayize) {
-
             if ($itemOfArray = $this->isArrayNestedElement($t)) {
                 if (!$t->getName()) {
-
                     if ($element instanceof ElementRef) {
                         $elRefClass = $this->visitElementDef($element->getSchema(), $element->getReferencedElement());
                         $itemClass = $this->findPHPClass($elRefClass, $element);
@@ -508,18 +512,18 @@ class YamlConverter extends AbstractConverter
 
                 $visited = $this->visitElement($classType, $schema, $itemOfArray, false);
 
-                $property["type"] = "array<" . $visited["type"] . ">";
-                $property["xml_list"]["inline"] = false;
-                $property["xml_list"]["entry_name"] = $itemOfArray->getName();
-                $property["xml_list"]["skip_when_empty"] = ($element->getMin() === 0);
+                $property['type'] = 'array<' . $visited['type'] . '>';
+                $property['xml_list']['inline'] = false;
+                $property['xml_list']['entry_name'] = $itemOfArray->getName();
+                $property['xml_list']['skip_when_empty'] = ($element->getMin() === 0);
 
                 $elementNamespace = $this->getElementNamespace($schema, $itemOfArray);
                 if ($elementNamespace) {
-                    $property["xml_list"]["namespace"] = $elementNamespace;
+                    $property['xml_list']['namespace'] = $elementNamespace;
                 }
+
                 return $property;
             } elseif ($itemOfArray = $this->isArrayType($t)) {
-
                 if (!$t->getName()) {
                     if ($element instanceof ElementRef) {
                         $elRefClass = $this->visitElementDef($element->getSchema(), $element->getReferencedElement());
@@ -533,38 +537,39 @@ class YamlConverter extends AbstractConverter
                     $visitedType = $this->visitType($itemOfArray);
                 }
                 if ($prop = $this->typeHasValue($itemOfArray, $class, 'xx')) {
-                    $property["type"] = "GoetasWebservices\Xsd\XsdToPhp\Jms\SimpleListOf<" . $prop . ">";
+                    $property['type'] = "GoetasWebservices\Xsd\XsdToPhp\Jms\SimpleListOf<" . $prop . '>';
                 } else {
-                    $property["type"] = "GoetasWebservices\Xsd\XsdToPhp\Jms\SimpleListOf<" . key($visitedType)  . ">";
+                    $property['type'] = "GoetasWebservices\Xsd\XsdToPhp\Jms\SimpleListOf<" . key($visitedType) . '>';
                 }
 
                 $elementNamespace = $this->getElementNamespace($schema, $element);
 
                 if ($elementNamespace != null) {
-                    $property["xml_list"]["namespace"] = $elementNamespace;
+                    $property['xml_list']['namespace'] = $elementNamespace;
                 }
+
                 return $property;
             } elseif ($this->isArrayElement($element)) {
-                $property["xml_list"]["inline"] = true;
-                $property["xml_list"]["entry_name"] = $element->getName();
+                $property['xml_list']['inline'] = true;
+                $property['xml_list']['entry_name'] = $element->getName();
 
                 $elementNamespace = $this->getElementNamespace($schema, $element);
                 if ($elementNamespace != null) {
-                    $property["xml_list"]["namespace"] = $elementNamespace;
+                    $property['xml_list']['namespace'] = $elementNamespace;
                 }
 
-                $property["type"] = "array<" . $this->findPHPClass($class, $element) . ">";
+                $property['type'] = 'array<' . $this->findPHPClass($class, $element) . '>';
+
                 return $property;
             }
         }
 
         if ($element instanceof ElementRef) {
-
             $elRefClass = $this->visitElementDef($element->getSchema(), $element->getReferencedElement());
 
-            $property["type"] = $this->findPHPClass($elRefClass, $element->getReferencedElement());
+            $property['type'] = $this->findPHPClass($elRefClass, $element->getReferencedElement());
         } else {
-            $property["type"] = $this->findPHPClass($class, $element);
+            $property['type'] = $this->findPHPClass($class, $element);
         }
 
         return $property;
@@ -580,6 +585,7 @@ class YamlConverter extends AbstractConverter
 
         if ($node instanceof ElementRef) {
             $elementRef = $this->visitElementDef($node->getSchema(), $node->getReferencedElement());
+
             return key($elementRef);
         }
 

--- a/src/Jms/YamlValidatorConverter.php
+++ b/src/Jms/YamlValidatorConverter.php
@@ -235,6 +235,7 @@ class YamlValidatorConverter extends YamlConverter
         $rules = $this->loadValidatorType($property, $type, $arrayized );
 
 
+
         if ($element->getMin() > 0) {
             $property['validation'][] = [
                 'NotNull' => null

--- a/src/Jms/YamlValidatorConverter.php
+++ b/src/Jms/YamlValidatorConverter.php
@@ -3,20 +3,20 @@
 namespace GoetasWebservices\Xsd\XsdToPhp\Jms;
 
 use GoetasWebservices\XML\XSDReader\Schema\Attribute\Attribute;
+use GoetasWebservices\XML\XSDReader\Schema\Attribute\AttributeItem;
 use GoetasWebservices\XML\XSDReader\Schema\Element\Element;
 use GoetasWebservices\XML\XSDReader\Schema\Element\ElementItem;
 use GoetasWebservices\XML\XSDReader\Schema\Schema;
 use GoetasWebservices\XML\XSDReader\Schema\Type\ComplexType;
 use GoetasWebservices\XML\XSDReader\Schema\Type\SimpleType;
 use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
-use GoetasWebservices\XML\XSDReader\Schema\Attribute\AttributeItem;
 use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass;
 use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPProperty;
 
 class YamlValidatorConverter extends YamlConverter
 {
     /**
-     * Clean the properties for only remaining valid rules for Symfony Validation Constraints
+     * Clean the properties for only remaining valid rules for Symfony Validation Constraints.
      *
      * @return PHPClass[]
      */
@@ -25,29 +25,23 @@ class YamlValidatorConverter extends YamlConverter
         $classes = parent::getTypes();
 
         foreach ($classes as $k => &$definition) {
-
             if (empty($definition[$k]['properties'])) {
                 unset($classes[$k]);
                 continue;
             }
 
             $properties = array_filter(array_map(function ($property) {
-
                 if (!empty($property['validation'])) {
-
-
-                    foreach ($property['validation'] as &$rule){
+                    foreach ($property['validation'] as &$rule) {
                         foreach ($rule as $type => &$item) {
-
                             if ($type === 'Valid') {
                                 continue;
                             } else {
-                                if (!is_array($item)){
+                                if (!is_array($item)) {
                                     $item = [];
                                 }
                                 $item['groups'] = ['xsd_rules'];
                             }
-
                         }
                         unset($item);
                     }
@@ -55,7 +49,6 @@ class YamlValidatorConverter extends YamlConverter
 
                     return $property['validation'];
                 }
-
 
                 return null;
             }, $definition[$k]['properties']));
@@ -66,7 +59,7 @@ class YamlValidatorConverter extends YamlConverter
             }
 
             $definition[$k] = [
-                'properties' => $properties
+                'properties' => $properties,
             ];
         }
 
@@ -75,18 +68,15 @@ class YamlValidatorConverter extends YamlConverter
 
     /**
      * Load and convert XSD' restrictions to Symfony Validation Constraints
-     * from a schema type
+     * from a schema type.
      *
-     * @param array $property
-     * @param Type $type
-     * @param boolean $arrayized
+     * @param bool $arrayized
      */
     private function loadValidatorType(array &$property, Type $type, $arrayized = false)
     {
         $rules = [];
 
         if (($restrictions = $type->getRestriction()) && $checks = $restrictions->getChecks()) {
-
             foreach ($checks as $key => $check) {
                 switch ($key) {
                     case 'enumeration':
@@ -94,8 +84,8 @@ class YamlValidatorConverter extends YamlConverter
                             'Choice' => [
                                 'choices' => array_map(function ($enum) {
                                     return $enum['value'];
-                                }, $check)
-                            ]
+                                }, $check),
+                            ],
                         ];
                         break;
 //                    fractionDigits totalDigits validation makes no sense in object validation
@@ -121,8 +111,8 @@ class YamlValidatorConverter extends YamlConverter
                             $rules[] = [
                                 'Length' => [
                                     'min' => $item['value'],
-                                    'max' => $item['value']
-                                ]
+                                    'max' => $item['value'],
+                                ],
                             ];
                         }
                         break;
@@ -130,8 +120,8 @@ class YamlValidatorConverter extends YamlConverter
                         foreach ($check as $item) {
                             $rules[] = [
                                 'Length' => [
-                                    'max' => $item['value']
-                                ]
+                                    'max' => $item['value'],
+                                ],
                             ];
                         }
                         break;
@@ -139,43 +129,43 @@ class YamlValidatorConverter extends YamlConverter
                         foreach ($check as $item) {
                             $rules[] = [
                                 'Length' => [
-                                    'min' => $item['value']
-                                ]
+                                    'min' => $item['value'],
+                                ],
                             ];
                         }
                         break;
                     case 'pattern':
                         foreach ($check as $item) {
                             $rules[] = [
-                                'Regex' => ['pattern' => "~{$item['value']}~"]
+                                'Regex' => ['pattern' => "~{$item['value']}~"],
                             ];
                         }
                         break;
                     case 'maxExclusive':
                         foreach ($check as $item) {
                             $rules[] = [
-                                'LessThan' => ['value' => $item['value']]
+                                'LessThan' => ['value' => $item['value']],
                             ];
                         }
                         break;
                     case 'maxInclusive':
                         foreach ($check as $item) {
                             $rules[] = [
-                                'LessThanOrEqual' => ['value' => $item['value']]
+                                'LessThanOrEqual' => ['value' => $item['value']],
                             ];
                         }
                         break;
                     case 'minExclusive':
                         foreach ($check as $item) {
                             $rules[] = [
-                                'GreaterThan' => ['value' => $item['value']]
+                                'GreaterThan' => ['value' => $item['value']],
                             ];
                         }
                         break;
                     case 'minInclusive':
                         foreach ($check as $item) {
                             $rules[] = [
-                                'GreaterThanOrEqual' => ['value' => $item['value']]
+                                'GreaterThanOrEqual' => ['value' => $item['value']],
                             ];
                         }
                         break;
@@ -192,11 +182,9 @@ class YamlValidatorConverter extends YamlConverter
 
     /**
      * Load and convert XSD' restrictions to Symfony Validation Constraints
-     * from a schema element including required rule
+     * from a schema element including required rule.
      *
-     * @param array $property
-     * @param ElementItem $element
-     * @param boolean $arrayize
+     * @param bool $arrayize
      */
     private function loadValidatorElement(array &$property, ElementItem $element)
     {
@@ -210,12 +198,12 @@ class YamlValidatorConverter extends YamlConverter
             if ($itemOfArray = $this->isArrayNestedElement($type)) {
                 $attrs = [
                     'min' => min($element->getMin(), $itemOfArray->getMin()),
-                    'max' => $itemOfArray->getMax()
+                    'max' => $itemOfArray->getMax(),
                 ];
-            }  elseif ($itemOfArray = $this->isArrayType($type)) {
+            } elseif ($itemOfArray = $this->isArrayType($type)) {
                 $attrs = [
                     'min' => min($element->getMin(), $itemOfArray->getMin()),
-                    'max' => $itemOfArray->getMax()
+                    'max' => $itemOfArray->getMax(),
                 ];
             } elseif ($this->isArrayElement($element)) {
 //                $attrs = [
@@ -232,40 +220,37 @@ class YamlValidatorConverter extends YamlConverter
             unset($attrs['max']);
         }
 
-        $rules = $this->loadValidatorType($property, $type, $arrayized );
-
-
+        $rules = $this->loadValidatorType($property, $type, $arrayized);
 
         if ($element->getMin() > 0) {
             $property['validation'][] = [
-                'NotNull' => null
+                'NotNull' => null,
             ];
         }
 
         if ($arrayized && count($attrs) > 0) {
             $property['validation'][] = [
-                 'Count' => $attrs
+                'Count' => $attrs,
             ];
         }
         if ($arrayized && count($rules) > 0) {
 //            $rules[] = ['Valid' => null];
             $property['validation'][] = [
-                'All' => ['constraints' => $rules]
+                'All' => ['constraints' => $rules],
             ];
         } elseif ($type instanceof ComplexType) {
             $property['validation'][] = [
-                'Valid' => null
+                'Valid' => null,
             ];
         }
     }
 
     /**
      * Load and convert XSD' restrictions to Symfony Validation Constraints
-     * from a schema attribute including required rule
+     * from a schema attribute including required rule.
      *
-     * @param array $property
      * @param AttributeItem $element
-     * @param boolean $arrayize
+     * @param bool          $arrayize
      */
     private function loadValidatorAttribute(array &$property, AttributeItem $attribute)
     {
@@ -278,19 +263,18 @@ class YamlValidatorConverter extends YamlConverter
         if ($attribute instanceof Attribute) {
             if ($attribute->getUse() === Attribute::USE_REQUIRED) {
                 $property['validation'][] = [
-                    'NotNull' => null
+                    'NotNull' => null,
                 ];
             }
         }
     }
 
     /**
-     * Override necessary to improve method to load validations from schema type
+     * Override necessary to improve method to load validations from schema type.
      *
      * @param PHPClass $class
-     * @param array $data
-     * @param SimpleType $type
-     * @param string $name
+     * @param array    $data
+     * @param string   $name
      */
     protected function visitSimpleType(&$class, &$data, SimpleType $type, $name)
     {
@@ -299,21 +283,20 @@ class YamlValidatorConverter extends YamlConverter
         if ($restriction = $type->getRestriction()) {
             $parent = $restriction->getBase();
             if ($parent instanceof Type) {
-                if (!isset($data["properties"]['__value'])) {
-                    $data["properties"]['__value'] = [];
+                if (!isset($data['properties']['__value'])) {
+                    $data['properties']['__value'] = [];
                 }
-                $this->loadValidatorType($data["properties"]['__value'], $type);
+                $this->loadValidatorType($data['properties']['__value'], $type);
             }
         }
     }
 
     /**
-     * Override necessary to improve method to load validations from schema element
+     * Override necessary to improve method to load validations from schema element.
      *
      * @param PHPClass $class
-     * @param Schema $schema
-     * @param ElementItem $element
-     * @param boolean $arrayize
+     * @param bool     $arrayize
+     *
      * @return PHPProperty
      */
     protected function &visitElement(&$class, Schema $schema, ElementItem $element, $arrayize = true)
@@ -321,17 +304,15 @@ class YamlValidatorConverter extends YamlConverter
         $property = parent::visitElement($class, $schema, $element, $arrayize);
 
         $this->loadValidatorElement($property, $element);
+
         return $property;
     }
 
-
-
     /**
-     * Override necessary to improve method to load validations from schema attribute
+     * Override necessary to improve method to load validations from schema attribute.
      *
      * @param PHPClass $class
-     * @param Schema $schema
-     * @param AttributeItem $attribute
+     *
      * @return array
      */
     protected function &visitAttribute(&$class, Schema $schema, AttributeItem $attribute)
@@ -344,20 +325,20 @@ class YamlValidatorConverter extends YamlConverter
     }
 
     /**
-     * Responsible for handler all properties from extension types
+     * Responsible for handler all properties from extension types.
      *
      * @param PHPClass $class
-     * @param array $data
-     * @param Type $type
-     * @param string $parentName
+     * @param array    $data
+     * @param string   $parentName
      */
     protected function &handleClassExtension(&$class, &$data, Type $type, $parentName)
     {
         $property = parent::handleClassExtension($class, $data, $type, $parentName);
 
-        $rules = $this->loadValidatorType($property, $type, false );
+        $rules = $this->loadValidatorType($property, $type, false);
 
         $property['validation'] = array_merge(!empty($property['validation']) ? $property['validation'] : [], $rules);
+
         return $property;
     }
 }

--- a/src/Naming/LongNamingStrategy.php
+++ b/src/Naming/LongNamingStrategy.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Naming;
 
 use Doctrine\Common\Inflector\Inflector;
@@ -88,12 +89,12 @@ class LongNamingStrategy implements NamingStrategy
 
     public function getTypeName(Type $type)
     {
-        return $this->classify($type->getName()) . "Type";
+        return $this->classify($type->getName()) . 'Type';
     }
 
     public function getAnonymousTypeName(Type $type, $parentName)
     {
-        return $this->classify($parentName) . "AnonymousType";
+        return $this->classify($parentName) . 'AnonymousType';
     }
 
     public function getItemName(Item $item)
@@ -102,16 +103,17 @@ class LongNamingStrategy implements NamingStrategy
         if (in_array(strtolower($name), $this->reservedWords)) {
             $name .= 'Xsd';
         }
+
         return $name;
     }
 
     public function getPropertyName($item)
     {
-        return Inflector::camelize(str_replace(".", " ", $item->getName()));
+        return Inflector::camelize(str_replace('.', ' ', $item->getName()));
     }
 
     private function classify($name)
     {
-        return Inflector::classify(str_replace(".", " ", $name));
+        return Inflector::classify(str_replace('.', ' ', $name));
     }
 }

--- a/src/Naming/NamingStrategy.php
+++ b/src/Naming/NamingStrategy.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Naming;
 
 use GoetasWebservices\XML\XSDReader\Schema\Item;
@@ -6,7 +7,6 @@ use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
 
 interface NamingStrategy
 {
-
     public function getTypeName(Type $type);
 
     public function getAnonymousTypeName(Type $type, $parentName);

--- a/src/Naming/ShortNamingStrategy.php
+++ b/src/Naming/ShortNamingStrategy.php
@@ -91,19 +91,20 @@ class ShortNamingStrategy implements NamingStrategy
     {
         $name = $this->classify($type->getName());
         if ($name && substr($name, -4) !== 'Type') {
-            $name .= "Type";
+            $name .= 'Type';
         }
+
         return $name;
     }
 
     public function getAnonymousTypeName(Type $type, $parentName)
     {
-        return $this->classify($parentName) . "AType";
+        return $this->classify($parentName) . 'AType';
     }
 
     public function getPropertyName($item)
     {
-        return Inflector::camelize(str_replace(".", " ", $item->getName()));
+        return Inflector::camelize(str_replace('.', ' ', $item->getName()));
     }
 
     public function getItemName(Item $item)
@@ -112,11 +113,12 @@ class ShortNamingStrategy implements NamingStrategy
         if (in_array(strtolower($name), $this->reservedWords)) {
             $name .= 'Xsd';
         }
+
         return $name;
     }
 
     private function classify($name)
     {
-        return Inflector::classify(str_replace(".", " ", $name));
+        return Inflector::classify(str_replace('.', ' ', $name));
     }
 }

--- a/src/PathGenerator/PathGeneratorException.php
+++ b/src/PathGenerator/PathGeneratorException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\PathGenerator;
 
 class PathGeneratorException extends \Exception

--- a/src/PathGenerator/Psr4PathGenerator.php
+++ b/src/PathGenerator/Psr4PathGenerator.php
@@ -1,12 +1,12 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\PathGenerator;
 
 abstract class Psr4PathGenerator
 {
+    protected $namespaces = [];
 
-    protected $namespaces = array();
-
-    public function __construct(array $targets = array())
+    public function __construct(array $targets = [])
     {
         $this->setTargets($targets);
     }
@@ -22,4 +22,3 @@ abstract class Psr4PathGenerator
         }
     }
 }
-

--- a/src/Php/ClassGenerator.php
+++ b/src/Php/ClassGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Php;
 
 use Doctrine\Common\Inflector\Inflector;
@@ -7,8 +8,8 @@ use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClassOf;
 use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPProperty;
 use Laminas\Code\Generator;
 use Laminas\Code\Generator\DocBlock\Tag\ParamTag;
-use Laminas\Code\Generator\DocBlock\Tag\VarTag;
 use Laminas\Code\Generator\DocBlock\Tag\ReturnTag;
+use Laminas\Code\Generator\DocBlock\Tag\VarTag;
 use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\MethodGenerator;
 use Laminas\Code\Generator\ParameterGenerator;
@@ -16,7 +17,6 @@ use Laminas\Code\Generator\PropertyGenerator;
 
 class ClassGenerator
 {
-
     private function handleBody(Generator\ClassGenerator $class, PHPClass $type)
     {
         foreach ($type->getProperties() as $prop) {
@@ -43,65 +43,65 @@ class ClassGenerator
 
         $docblock = new DocBlockGenerator('Construct');
         $docblock->setWordWrap(false);
-        $paramTag = new ParamTag("value");
-        $paramTag->setTypes(($type ? $type->getPhpType() : "mixed"));
+        $paramTag = new ParamTag('value');
+        $paramTag->setTypes(($type ? $type->getPhpType() : 'mixed'));
 
         $docblock->setTag($paramTag);
 
-        $param = new ParameterGenerator("value");
+        $param = new ParameterGenerator('value');
         if ($type && !$type->isNativeType()) {
             $param->setType($type->getPhpType());
         }
-        $method = new MethodGenerator("__construct", [
-            $param
+        $method = new MethodGenerator('__construct', [
+            $param,
         ]);
         $method->setDocBlock($docblock);
-        $method->setBody("\$this->value(\$value);");
+        $method->setBody('$this->value($value);');
 
         $generator->addMethodFromGenerator($method);
 
         $docblock = new DocBlockGenerator('Gets or sets the inner value');
         $docblock->setWordWrap(false);
-        $paramTag = new ParamTag("value");
+        $paramTag = new ParamTag('value');
         if ($type && $type instanceof PHPClassOf) {
-            $paramTag->setTypes($type->getArg()->getType()->getPhpType() . "[]");
+            $paramTag->setTypes($type->getArg()->getType()->getPhpType() . '[]');
         } elseif ($type) {
             $paramTag->setTypes($prop->getType()->getPhpType());
         }
         $docblock->setTag($paramTag);
 
-        $returnTag = new ReturnTag("mixed");
+        $returnTag = new ReturnTag('mixed');
 
         if ($type && $type instanceof PHPClassOf) {
-            $returnTag->setTypes($type->getArg()->getType()->getPhpType() . "[]");
+            $returnTag->setTypes($type->getArg()->getType()->getPhpType() . '[]');
         } elseif ($type) {
             $returnTag->setTypes($type->getPhpType());
         }
         $docblock->setTag($returnTag);
 
-        $param = new ParameterGenerator("value");
+        $param = new ParameterGenerator('value');
         $param->setDefaultValue(null);
 
         if ($type && !$type->isNativeType()) {
             $param->setType($type->getPhpType());
         }
-        $method = new MethodGenerator("value", []);
+        $method = new MethodGenerator('value', []);
         $method->setDocBlock($docblock);
 
-        $methodBody = "if (\$args = func_get_args()) {" . PHP_EOL;
-        $methodBody .= "    \$this->" . $prop->getName() . " = \$args[0];" . PHP_EOL;
-        $methodBody .= "}" . PHP_EOL;
-        $methodBody .= "return \$this->" . $prop->getName() . ";" . PHP_EOL;
+        $methodBody = 'if ($args = func_get_args()) {' . PHP_EOL;
+        $methodBody .= '    $this->' . $prop->getName() . ' = $args[0];' . PHP_EOL;
+        $methodBody .= '}' . PHP_EOL;
+        $methodBody .= 'return $this->' . $prop->getName() . ';' . PHP_EOL;
         $method->setBody($methodBody);
 
         $generator->addMethodFromGenerator($method);
 
         $docblock = new DocBlockGenerator('Gets a string value');
         $docblock->setWordWrap(false);
-        $docblock->setTag(new ReturnTag("string"));
-        $method = new MethodGenerator("__toString");
+        $docblock->setTag(new ReturnTag('string'));
+        $method = new MethodGenerator('__toString');
         $method->setDocBlock($docblock);
-        $method->setBody("return strval(\$this->" . $prop->getName() . ");");
+        $method->setBody('return strval($this->' . $prop->getName() . ');');
         $generator->addMethodFromGenerator($method);
     }
 
@@ -111,7 +111,7 @@ class ClassGenerator
         $docblock = new DocBlockGenerator();
         $docblock->setWordWrap(false);
 
-        $docblock->setShortDescription("Sets a new " . $prop->getName());
+        $docblock->setShortDescription('Sets a new ' . $prop->getName());
 
         if ($prop->getDoc()) {
             $docblock->setLongDescription($prop->getDoc());
@@ -120,19 +120,19 @@ class ClassGenerator
         $patramTag = new ParamTag($prop->getName());
         $docblock->setTag($patramTag);
 
-        $return = new ReturnTag("self");
+        $return = new ReturnTag('self');
         $docblock->setTag($return);
 
         $type = $prop->getType();
 
-        $method = new MethodGenerator("set" . Inflector::classify($prop->getName()));
+        $method = new MethodGenerator('set' . Inflector::classify($prop->getName()));
 
         $parameter = new ParameterGenerator($prop->getName());
 
         if ($type && $type instanceof PHPClassOf) {
             $patramTag->setTypes($type->getArg()
-                    ->getType()->getPhpType() . "[]");
-            $parameter->setType("array");
+                    ->getType()->getPhpType() . '[]');
+            $parameter->setType('array');
 
             if ($p = $type->getArg()->getType()->isSimpleType()
             ) {
@@ -159,8 +159,8 @@ class ClassGenerator
             }
         }
 
-        $methodBody .= "\$this->" . $prop->getName() . " = \$" . $prop->getName() . ";" . PHP_EOL;
-        $methodBody .= "return \$this;";
+        $methodBody .= '$this->' . $prop->getName() . ' = $' . $prop->getName() . ';' . PHP_EOL;
+        $methodBody .= 'return $this;';
         $method->setBody($methodBody);
         $method->setDocBlock($docblock);
         $method->setParameter($parameter);
@@ -170,44 +170,42 @@ class ClassGenerator
 
     private function handleGetter(Generator\ClassGenerator $generator, PHPProperty $prop, PHPClass $class)
     {
-
         if ($prop->getType() instanceof PHPClassOf) {
             $docblock = new DocBlockGenerator();
             $docblock->setWordWrap(false);
-            $docblock->setShortDescription("isset " . $prop->getName());
+            $docblock->setShortDescription('isset ' . $prop->getName());
             if ($prop->getDoc()) {
                 $docblock->setLongDescription($prop->getDoc());
             }
 
-            $patramTag = new ParamTag("index", "int|string");
+            $patramTag = new ParamTag('index', 'int|string');
             $docblock->setTag($patramTag);
 
-            $docblock->setTag(new ReturnTag("bool"));
+            $docblock->setTag(new ReturnTag('bool'));
 
-            $paramIndex = new ParameterGenerator("index");
+            $paramIndex = new ParameterGenerator('index');
 
-            $method = new MethodGenerator("isset" . Inflector::classify($prop->getName()), [$paramIndex]);
+            $method = new MethodGenerator('isset' . Inflector::classify($prop->getName()), [$paramIndex]);
             $method->setDocBlock($docblock);
-            $method->setBody("return isset(\$this->" . $prop->getName() . "[\$index]);");
+            $method->setBody('return isset($this->' . $prop->getName() . '[$index]);');
             $generator->addMethodFromGenerator($method);
 
             $docblock = new DocBlockGenerator();
             $docblock->setWordWrap(false);
-            $docblock->setShortDescription("unset " . $prop->getName());
+            $docblock->setShortDescription('unset ' . $prop->getName());
             if ($prop->getDoc()) {
                 $docblock->setLongDescription($prop->getDoc());
             }
 
-            $patramTag = new ParamTag("index", "int|string");
+            $patramTag = new ParamTag('index', 'int|string');
             $docblock->setTag($patramTag);
-            $paramIndex = new ParameterGenerator("index");
+            $paramIndex = new ParameterGenerator('index');
 
-            $docblock->setTag(new ReturnTag("void"));
+            $docblock->setTag(new ReturnTag('void'));
 
-
-            $method = new MethodGenerator("unset" . Inflector::classify($prop->getName()), [$paramIndex]);
+            $method = new MethodGenerator('unset' . Inflector::classify($prop->getName()), [$paramIndex]);
             $method->setDocBlock($docblock);
-            $method->setBody("unset(\$this->" . $prop->getName() . "[\$index]);");
+            $method->setBody('unset($this->' . $prop->getName() . '[$index]);');
             $generator->addMethodFromGenerator($method);
         }
         // ////
@@ -215,24 +213,23 @@ class ClassGenerator
         $docblock = new DocBlockGenerator();
         $docblock->setWordWrap(false);
 
-        $docblock->setShortDescription("Gets as " . $prop->getName());
+        $docblock->setShortDescription('Gets as ' . $prop->getName());
 
         if ($prop->getDoc()) {
             $docblock->setLongDescription($prop->getDoc());
         }
 
-        $tag = new ReturnTag("mixed");
+        $tag = new ReturnTag('mixed');
         $type = $prop->getType();
         if ($type && $type instanceof PHPClassOf) {
             $tt = $type->getArg()->getType();
-            $tag->setTypes($tt->getPhpType() . "[]");
+            $tag->setTypes($tt->getPhpType() . '[]');
             if ($p = $tt->isSimpleType()) {
                 if (($t = $p->getType())) {
-                    $tag->setTypes($t->getPhpType() . "[]");
+                    $tag->setTypes($t->getPhpType() . '[]');
                 }
             }
         } elseif ($type) {
-
             if ($p = $type->isSimpleType()) {
                 if ($t = $p->getType()) {
                     $tag->setTypes($t->getPhpType());
@@ -244,9 +241,9 @@ class ClassGenerator
 
         $docblock->setTag($tag);
 
-        $method = new MethodGenerator("get" . Inflector::classify($prop->getName()));
+        $method = new MethodGenerator('get' . Inflector::classify($prop->getName()));
         $method->setDocBlock($docblock);
-        $method->setBody("return \$this->" . $prop->getName() . ";");
+        $method->setBody('return $this->' . $prop->getName() . ';');
 
         $generator->addMethodFromGenerator($method);
     }
@@ -265,19 +262,18 @@ class ClassGenerator
         }
 
         $return = new ReturnTag();
-        $return->setTypes("self");
+        $return->setTypes('self');
         $docblock->setTag($return);
 
         $patramTag = new ParamTag($propName, $type->getArg()->getType()->getPhpType());
         $docblock->setTag($patramTag);
 
-        $method = new MethodGenerator("addTo" . Inflector::classify($prop->getName()));
+        $method = new MethodGenerator('addTo' . Inflector::classify($prop->getName()));
 
         $parameter = new ParameterGenerator($propName);
         $tt = $type->getArg()->getType();
 
         if (!$tt->isNativeType()) {
-
             if ($p = $tt->isSimpleType()) {
                 if (($t = $p->getType())) {
                     $patramTag->setTypes($t->getPhpType());
@@ -291,8 +287,8 @@ class ClassGenerator
             }
         }
 
-        $methodBody = "\$this->" . $prop->getName() . "[] = \$" . $propName . ";" . PHP_EOL;
-        $methodBody .= "return \$this;";
+        $methodBody = '$this->' . $prop->getName() . '[] = $' . $propName . ';' . PHP_EOL;
+        $methodBody .= 'return $this;';
         $method->setBody($methodBody);
         $method->setDocBlock($docblock);
         $method->setParameter($parameter);
@@ -317,7 +313,7 @@ class ClassGenerator
 
         $class->addPropertyFromGenerator($generatedProp);
 
-        if ($prop->getType() && (!$prop->getType()->getNamespace() && $prop->getType()->getName() == "array")) {
+        if ($prop->getType() && (!$prop->getType()->getNamespace() && $prop->getType()->getName() == 'array')) {
             // $generatedProp->setDefaultValue(array(), PropertyValueGenerator::TYPE_AUTO, PropertyValueGenerator::OUTPUT_SINGLE_LINE);
         }
 
@@ -334,15 +330,14 @@ class ClassGenerator
 
         if ($type && $type instanceof PHPClassOf) {
             $tt = $type->getArg()->getType();
-            $tag->setTypes($tt->getPhpType() . "[]");
+            $tag->setTypes($tt->getPhpType() . '[]');
             if ($p = $tt->isSimpleType()) {
                 if (($t = $p->getType())) {
-                    $tag->setTypes($t->getPhpType() . "[]");
+                    $tag->setTypes($t->getPhpType() . '[]');
                 }
             }
             $generatedProp->setDefaultValue($type->getArg()->getDefault());
         } elseif ($type) {
-
             if ($type->isNativeType()) {
                 $tag->setTypes($type->getPhpType());
             } elseif (($p = $type->isSimpleType()) && ($t = $p->getType())) {
@@ -357,27 +352,25 @@ class ClassGenerator
     public function generate(PHPClass $type)
     {
         $class = new \Laminas\Code\Generator\ClassGenerator();
-        $docblock = new DocBlockGenerator("Class representing " . $type->getName());
+        $docblock = new DocBlockGenerator('Class representing ' . $type->getName());
         $docblock->setWordWrap(false);
         if ($type->getDoc()) {
             $docblock->setLongDescription($type->getDoc());
         }
-        $class->setNamespaceName($type->getNamespace() ?: NULL);
+        $class->setNamespaceName($type->getNamespace() ?: null);
         $class->setName($type->getName());
         $class->setDocblock($docblock);
 
         if ($extends = $type->getExtends()) {
-
             if ($p = $extends->isSimpleType()) {
                 $this->handleProperty($class, $p);
                 $this->handleValueMethod($class, $p, $extends);
             } else {
-
                 $class->setExtendedClass($extends->getFullName());
 
                 if ($extends->getNamespace() != $type->getNamespace()) {
                     if ($extends->getName() == $type->getName()) {
-                        $class->addUse($type->getExtends()->getFullName(), $extends->getName() . "Base");
+                        $class->addUse($type->getExtends()->getFullName(), $extends->getName() . 'Base');
                     } else {
                         $class->addUse($extends->getFullName());
                     }

--- a/src/Php/PathGenerator/PathGenerator.php
+++ b/src/Php/PathGenerator/PathGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Php\PathGenerator;
 
 use Laminas\Code\Generator\ClassGenerator;

--- a/src/Php/PathGenerator/Psr4PathGenerator.php
+++ b/src/Php/PathGenerator/Psr4PathGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Php\PathGenerator;
 
 use GoetasWebservices\Xsd\XsdToPhp\PathGenerator\PathGeneratorException;
@@ -10,20 +11,18 @@ class Psr4PathGenerator extends Psr4PathGeneratorBase implements PathGenerator
     public function getPath(ClassGenerator $php)
     {
         foreach ($this->namespaces as $namespace => $dir) {
-
-            if (strpos(trim($php->getNamespaceName()) . "\\", $namespace) === 0) {
-                $d = strtr(substr($php->getNamespaceName(), strlen($namespace)), "\\", "/");
-                $dir = rtrim($dir, "/") . "/" . $d;
+            if (strpos(trim($php->getNamespaceName()) . '\\', $namespace) === 0) {
+                $d = strtr(substr($php->getNamespaceName(), strlen($namespace)), '\\', '/');
+                $dir = rtrim($dir, '/') . '/' . $d;
                 if (!is_dir($dir) && !@mkdir($dir, 0777, true)) {
                     $error = error_get_last();
                     throw new PathGeneratorException("Can't create the '$dir' directory: '{$error['message']}'");
                 }
 
-                return rtrim($dir, "/") . "/" . $php->getName() . ".php";
+                return rtrim($dir, '/') . '/' . $php->getName() . '.php';
             }
         }
 
         throw new PathGeneratorException("Unable to determine location to save PHP class '{$php->getNamespaceName()}\\{$php->getName()}'");
     }
 }
-

--- a/src/Php/PhpConverter.php
+++ b/src/Php/PhpConverter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Php;
 
 use Exception;
@@ -25,28 +26,27 @@ use Psr\Log\LoggerInterface;
 
 class PhpConverter extends AbstractConverter
 {
-
     public function __construct(NamingStrategy $namingStrategy, LoggerInterface $loggerInterface = null)
     {
         parent::__construct($namingStrategy, $loggerInterface);
 
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "dateTime", function (Type $type) {
-            return "DateTime";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'dateTime', function (Type $type) {
+            return 'DateTime';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "time", function (Type $type) {
-            return "DateTime";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'time', function (Type $type) {
+            return 'DateTime';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "date", function (Type $type) {
-            return "DateTime";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'date', function (Type $type) {
+            return 'DateTime';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "anySimpleType", function (Type $type) {
-            return "mixed";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'anySimpleType', function (Type $type) {
+            return 'mixed';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "anyType", function (Type $type) {
-            return "mixed";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'anyType', function (Type $type) {
+            return 'mixed';
         });
-        $this->addAliasMap("http://www.w3.org/2001/XMLSchema", "base64Binary", function (Type $type) {
-            return "string";
+        $this->addAliasMap('http://www.w3.org/2001/XMLSchema', 'base64Binary', function (Type $type) {
+            return 'string';
         });
     }
 
@@ -54,27 +54,27 @@ class PhpConverter extends AbstractConverter
 
     public function convert(array $schemas)
     {
-        $visited = array();
-        $this->classes = array();
+        $visited = [];
+        $this->classes = [];
         foreach ($schemas as $schema) {
             $this->navigate($schema, $visited);
         }
+
         return $this->getTypes();
     }
 
     /**
-     *
      * @return PHPClass[]
      */
     private function getTypes()
     {
         uasort($this->classes, function ($a, $b) {
-            return strcmp($a["class"]->getFullName(), $b["class"]->getFullName());
+            return strcmp($a['class']->getFullName(), $b['class']->getFullName());
         });
-        $ret = array();
+        $ret = [];
         foreach ($this->classes as $classData) {
-            if (empty($classData["skip"])) {
-                $ret[$classData["class"]->getFullName()] = $classData["class"];
+            if (empty($classData['skip'])) {
+                $ret[$classData['class']->getFullName()] = $classData['class'];
             }
         }
 
@@ -144,8 +144,8 @@ class PhpConverter extends AbstractConverter
     private $skipByType = [];
 
     /**
-     * @param ElementDef $element
      * @param bool $skip
+     *
      * @return PHPClass
      */
     public function visitElementDef(ElementDef $element)
@@ -175,12 +175,12 @@ class PhpConverter extends AbstractConverter
                 || $this->getTypeAlias($type, $type->getSchema())
                 || $typeClass->getPropertyInHierarchy('__value')
             ;
-            $this->classes[spl_object_hash($element)]["class"] = $class;
-            $this->classes[spl_object_hash($element)]["skip"] = $skip;
+            $this->classes[spl_object_hash($element)]['class'] = $class;
+            $this->classes[spl_object_hash($element)]['skip'] = $skip;
             $this->skipByType[spl_object_hash($class)] = $skip;
-
         }
-        return $this->classes[spl_object_hash($element)]["class"];
+
+        return $this->classes[spl_object_hash($element)]['class'];
     }
 
     public function isSkip($class)
@@ -193,16 +193,15 @@ class PhpConverter extends AbstractConverter
         $schema = $type->getSchema();
 
         if ($className = $this->getTypeAlias($type)) {
-
             if (($pos = strrpos($className, '\\')) !== false) {
                 return [
                     substr($className, $pos + 1),
-                    substr($className, 0, $pos)
+                    substr($className, 0, $pos),
                 ];
             } else {
                 return [
                     $className,
-                    null
+                    null,
                 ];
             }
         }
@@ -213,86 +212,90 @@ class PhpConverter extends AbstractConverter
             throw new Exception(sprintf("Can't find a PHP namespace to '%s' namespace", $schema->getTargetNamespace()));
         }
         $ns = $this->namespaces[$schema->getTargetNamespace()];
+
         return [
             $name,
-            $ns
+            $ns,
         ];
     }
 
     /**
-     *
-     * @param Type $type
      * @param bool $force
      * @param bool $skip
+     *
      * @return PHPClass
+     *
      * @throws Exception
      */
-    public function visitType(Type $type, $force = false, $skip = false)
+    public function visitType(Type $type, $force = false)
     {
         if (!isset($this->classes[spl_object_hash($type)])) {
+            $skip = in_array($type->getSchema()->getTargetNamespace(), $this->baseSchemas, true);
 
-            $skip = $skip || in_array($type->getSchema()->getTargetNamespace(), $this->baseSchemas, true);
-
-            $this->classes[spl_object_hash($type)]["class"] = $class = new PHPClass();
+            $this->classes[spl_object_hash($type)]['class'] = $class = new PHPClass();
 
             if ($alias = $this->getTypeAlias($type)) {
                 $class->setName($alias);
-                $this->classes[spl_object_hash($type)]["skip"] = true;
+                $this->classes[spl_object_hash($type)]['skip'] = true;
                 $this->skipByType[spl_object_hash($class)] = true;
+
                 return $class;
             }
 
-            list ($name, $ns) = $this->findPHPName($type);
+            list($name, $ns) = $this->findPHPName($type);
             $class->setName($name);
             $class->setNamespace($ns);
 
-            $class->setDoc($type->getDoc() . PHP_EOL . "XSD Type: " . ($type->getName() ?: 'anonymous'));
+            $class->setDoc($type->getDoc() . PHP_EOL . 'XSD Type: ' . ($type->getName() ?: 'anonymous'));
 
             $this->visitTypeBase($class, $type);
 
             if ($type instanceof SimpleType) {
-                $this->classes[spl_object_hash($type)]["skip"] = true;
+                $this->classes[spl_object_hash($type)]['skip'] = true;
                 $this->skipByType[spl_object_hash($class)] = true;
+
                 return $class;
             }
             if (($this->isArrayType($type) || $this->isArrayNestedElement($type)) && !$force) {
-                $this->classes[spl_object_hash($type)]["skip"] = true;
+                $this->classes[spl_object_hash($type)]['skip'] = true;
                 $this->skipByType[spl_object_hash($class)] = true;
+
                 return $class;
             }
 
-            $this->classes[spl_object_hash($type)]["skip"] = $skip || !!$this->getTypeAlias($type);
+            $this->classes[spl_object_hash($type)]['skip'] = $skip || (bool) $this->getTypeAlias($type);
         } elseif ($force) {
             if (!($type instanceof SimpleType) && !$this->getTypeAlias($type)) {
-                $this->classes[spl_object_hash($type)]["skip"] = in_array($type->getSchema()->getTargetNamespace(), $this->baseSchemas, true);
+                $this->classes[spl_object_hash($type)]['skip'] = in_array($type->getSchema()->getTargetNamespace(), $this->baseSchemas, true);
             }
         }
-        return $this->classes[spl_object_hash($type)]["class"];
+
+        return $this->classes[spl_object_hash($type)]['class'];
     }
 
     /**
-     * @param Type $type
      * @param string $name
-     * @param PHPClass $parentClass
+     *
      * @return \GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass
      */
     private function visitTypeAnonymous(Type $type, $name, PHPClass $parentClass)
     {
         if (!isset($this->classes[spl_object_hash($type)])) {
-            $this->classes[spl_object_hash($type)]["class"] = $class = new PHPClass();
+            $this->classes[spl_object_hash($type)]['class'] = $class = new PHPClass();
             $class->setName($this->getNamingStrategy()->getAnonymousTypeName($type, $name));
 
-            $class->setNamespace($parentClass->getNamespace() . "\\" . $parentClass->getName());
+            $class->setNamespace($parentClass->getNamespace() . '\\' . $parentClass->getName());
             $class->setDoc($type->getDoc());
 
             $this->visitTypeBase($class, $type);
 
             if ($type instanceof SimpleType) {
-                $this->classes[spl_object_hash($type)]["skip"] = true;
+                $this->classes[spl_object_hash($type)]['skip'] = true;
                 $this->skipByType[spl_object_hash($class)] = true;
             }
         }
-        return $this->classes[spl_object_hash($type)]["class"];
+
+        return $this->classes[spl_object_hash($type)]['class'];
     }
 
     private function visitComplexType(PHPClass $class, ComplexType $type)
@@ -323,7 +326,7 @@ class PhpConverter extends AbstractConverter
                 }
             }
         } elseif ($unions = $type->getUnions()) {
-            $types = array();
+            $types = [];
             foreach ($unions as $i => $unon) {
                 if (!$unon->getName()) {
                     $types[] = $this->visitTypeAnonymous($unon, $type->getName() . $i, $class);
@@ -340,7 +343,6 @@ class PhpConverter extends AbstractConverter
 
     private function handleClassExtension(PHPClass $class, Type $type)
     {
-
         if ($alias = $this->getTypeAlias($type)) {
             $c = PHPClass::createFromFQCN($alias);
             $val = new PHPProperty('__value');
@@ -393,15 +395,14 @@ class PhpConverter extends AbstractConverter
         }
 
         $property->setDoc($attribute->getDoc());
+
         return $property;
     }
 
     /**
-     *
-     * @param PHPClass $class
-     * @param Schema $schema
      * @param Element $element
-     * @param bool $arrayize
+     * @param bool    $arrayize
+     *
      * @return \GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPProperty
      */
     private function visitElement(PHPClass $class, Schema $schema, ElementSingle $element, $arrayize = true)
@@ -414,7 +415,6 @@ class PhpConverter extends AbstractConverter
 
         if ($arrayize) {
             if ($itemOfArray = $this->isArrayType($t)) {
-
                 if (!$itemOfArray->getName()) {
                     if ($element instanceof ElementRef) {
                         $refClass = $this->visitElementDef($element->getReferencedElement());
@@ -431,6 +431,7 @@ class PhpConverter extends AbstractConverter
                 $arg = new PHPArg($this->getNamingStrategy()->getPropertyName($element));
                 $arg->setType($classType);
                 $property->setType(new PHPClassOf($arg));
+
                 return $property;
             } elseif ($itemOfArray = $this->isArrayNestedElement($t)) {
                 if (!$t->getName()) {
@@ -447,17 +448,18 @@ class PhpConverter extends AbstractConverter
                 }
                 $elementProp = $this->visitElement($classType, $schema, $itemOfArray, false);
                 $property->setType(new PHPClassOf($elementProp));
+
                 return $property;
             } elseif ($this->isArrayElement($element)) {
                 $arg = new PHPArg($this->getNamingStrategy()->getPropertyName($element));
 
                 $arg->setType($this->findPHPClass($class, $element));
-                $arg->setDefault(array());
+                $arg->setDefault([]);
                 $property->setType(new PHPClassOf($arg));
+
                 return $property;
             }
         }
-
 
         if ($element instanceof ElementRef) {
             $refClass = $this->visitElementDef($element->getReferencedElement());
@@ -471,7 +473,6 @@ class PhpConverter extends AbstractConverter
 
     private function findPHPClass(PHPClass $class, Item $node, $force = false)
     {
-
         if ($node instanceof ElementRef) {
             return $this->visitElementDef($node->getReferencedElement());
         }

--- a/src/Php/Structure/PHPArg.php
+++ b/src/Php/Structure/PHPArg.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Php\Structure;
 
 class PHPArg
 {
-
     protected $doc;
 
     protected $type;
@@ -26,6 +26,7 @@ class PHPArg
     public function setDoc($doc)
     {
         $this->doc = $doc;
+
         return $this;
     }
 
@@ -40,6 +41,7 @@ class PHPArg
     public function setType(PHPClass $type)
     {
         $this->type = $type;
+
         return $this;
     }
 
@@ -51,6 +53,7 @@ class PHPArg
     public function setName($name)
     {
         $this->name = $name;
+
         return $this;
     }
 
@@ -62,6 +65,7 @@ class PHPArg
     public function setDefault($default)
     {
         $this->default = $default;
+
         return $this;
     }
 }

--- a/src/Php/Structure/PHPClass.php
+++ b/src/Php/Structure/PHPClass.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Php\Structure;
 
 class PHPClass
 {
-
     protected $name;
 
     protected $namespace;
@@ -21,6 +21,7 @@ class PHPClass
 
     /**
      * @param bool $onlyParent
+     *
      * @return PHPProperty
      */
     public function isSimpleType($onlyParent = false)
@@ -34,7 +35,7 @@ class PHPClass
             }
         } else {
             if ($this->hasPropertyInHierarchy('__value') && count($this->getPropertiesInHierarchy()) === 1) {
-                return $this->getPropertyInHierarchy("__value");
+                return $this->getPropertyInHierarchy('__value');
             }
         }
     }
@@ -45,9 +46,11 @@ class PHPClass
             if ($this->isNativeType()) {
                 return $this->getName();
             }
-            return "\\" . $this->getName();
+
+            return '\\' . $this->getName();
         }
-        return "\\" . $this->getFullName();
+
+        return '\\' . $this->getFullName();
     }
 
     public function isNativeType()
@@ -60,10 +63,9 @@ class PHPClass
             'array',
             'callable',
 
-            'mixed' //todo this is not a php type but it's needed for now to allow mixed return tags
+            'mixed', //todo this is not a php type but it's needed for now to allow mixed return tags
         ]);
     }
-
 
     public function __construct($name = null, $namespace = null)
     {
@@ -79,6 +81,7 @@ class PHPClass
     public function setName($name)
     {
         $this->name = $name;
+
         return $this;
     }
 
@@ -90,6 +93,7 @@ class PHPClass
     public function setNamespace($namespace)
     {
         $this->namespace = $namespace;
+
         return $this;
     }
 
@@ -101,6 +105,7 @@ class PHPClass
     public function setDoc($doc)
     {
         $this->doc = $doc;
+
         return $this;
     }
 
@@ -114,49 +119,47 @@ class PHPClass
         return "{$this->namespace}\\{$this->name}";
     }
 
-    protected $checks = array();
+    protected $checks = [];
 
     /**
-     *
      * @var PHPConstant[]
      */
-    protected $constants = array();
+    protected $constants = [];
 
     /**
-     *
      * @var PHPProperty[]
      */
-    protected $properties = array();
+    protected $properties = [];
 
     /**
-     *
      * @param
      *            $property
+     *
      * @return array
      */
     public function getChecks($property)
     {
-        return isset($this->checks[$property]) ? $this->checks[$property] : array();
+        return isset($this->checks[$property]) ? $this->checks[$property] : [];
     }
 
     /**
-     *
      * @param
      *            $property
      * @param
      *            $check
      * @param
      *            $value
+     *
      * @return $this
      */
     public function addCheck($property, $check, $value)
     {
         $this->checks[$property][$check][] = $value;
+
         return $this;
     }
 
     /**
-     *
      * @return PHPProperty[]
      */
     public function getProperties()
@@ -165,8 +168,8 @@ class PHPClass
     }
 
     /**
-     *
      * @param string $name
+     *
      * @return bool
      */
     public function hasProperty($name)
@@ -175,40 +178,49 @@ class PHPClass
     }
 
     /**
-     *
      * @param string $name
+     *
      * @return bool
      */
     public function hasPropertyInHierarchy($name)
     {
+        if (count($this->getProperties()) > 1 || (count($this->getProperties()) > 0 && !$this->hasProperty($name))) {
+            return false;
+        }
         if ($this->hasProperty($name)) {
             return true;
         }
         if (($this instanceof PHPClass) && $this->getExtends() && $this->getExtends()->hasPropertyInHierarchy($name)) {
             return true;
         }
+
         return false;
     }
 
     /**
-     *
      * @param string $name
+     *
      * @return PHPProperty
      */
     public function getPropertyInHierarchy($name)
     {
+        if (count($this->getProperties()) > 1 || (count($this->getProperties()) > 0 && !$this->hasProperty($name))) {
+            return null;
+        }
+
         if ($this->hasProperty($name)) {
             return $this->getProperty($name);
         }
         if (($this instanceof PHPClass) && $this->getExtends() && $this->getExtends()->hasPropertyInHierarchy($name)) {
             return $this->getExtends()->getPropertyInHierarchy($name);
         }
+
         return null;
     }
 
     /**
-     *
      * @param string $name
+     *
      * @return PHPProperty
      */
     public function getPropertiesInHierarchy()
@@ -223,8 +235,8 @@ class PHPClass
     }
 
     /**
-     *
      * @param string $name
+     *
      * @return PHPProperty
      */
     public function getProperty($name)
@@ -233,30 +245,26 @@ class PHPClass
     }
 
     /**
-     *
-     * @param PHPProperty $property
      * @return $this
      */
     public function addProperty(PHPProperty $property)
     {
         $this->properties[$property->getName()] = $property;
+
         return $this;
     }
 
     /**
-     *
      * @var bool
      */
     protected $abstract;
 
     /**
-     *
      * @var PHPClass
      */
     protected $extends;
 
     /**
-     *
      * @return PHPClass
      */
     public function getExtends()
@@ -265,13 +273,12 @@ class PHPClass
     }
 
     /**
-     *
-     * @param PHPClass $extends
      * @return PHPClass
      */
     public function setExtends(PHPClass $extends)
     {
         $this->extends = $extends;
+
         return $this;
     }
 
@@ -282,7 +289,8 @@ class PHPClass
 
     public function setAbstract($abstract)
     {
-        $this->abstract = (bool)$abstract;
+        $this->abstract = (bool) $abstract;
+
         return $this;
     }
 }

--- a/src/Php/Structure/PHPClassOf.php
+++ b/src/Php/Structure/PHPClassOf.php
@@ -1,17 +1,14 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Php\Structure;
 
 class PHPClassOf extends PHPClass
 {
-
     /**
      * @var PHPArg
      */
     protected $arg;
 
-    /**
-     * @param PHPArg $arg
-     */
     public function __construct(PHPArg $arg)
     {
         $this->arg = $arg;
@@ -23,7 +20,7 @@ class PHPClassOf extends PHPClass
      */
     public function __toString()
     {
-        return "array of " . $this->arg;
+        return 'array of ' . $this->arg;
     }
 
     /**
@@ -34,4 +31,3 @@ class PHPClassOf extends PHPClass
         return $this->arg;
     }
 }
-

--- a/src/Php/Structure/PHPProperty.php
+++ b/src/Php/Structure/PHPProperty.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Php\Structure;
 
 class PHPProperty extends PHPArg
 {
-
     /**
      * @var string
      */
@@ -19,11 +19,13 @@ class PHPProperty extends PHPArg
 
     /**
      * @param string $visibility
+     *
      * @return $this
      */
     public function setVisibility($visibility)
     {
         $this->visibility = $visibility;
+
         return $this;
     }
 }

--- a/src/Writer/JMSWriter.php
+++ b/src/Writer/JMSWriter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Writer;
 
 use GoetasWebservices\Xsd\XsdToPhp\Jms\PathGenerator\PathGenerator;
@@ -29,8 +30,8 @@ class JMSWriter extends Writer implements LoggerAwareInterface
             $source = $dumper->dump($item, 10000);
             $path = $this->pathGenerator->getPath($item);
             file_put_contents($path, $source);
-            $this->logger->debug(sprintf("Written JMS metadata file %s", $path));
+            $this->logger->debug(sprintf('Written JMS metadata file %s', $path));
         }
-        $this->logger->info(sprintf("Written %s JMS metadata files ", count($items)));
+        $this->logger->info(sprintf('Written %s JMS metadata files ', count($items)));
     }
 }

--- a/src/Writer/PHPClassWriter.php
+++ b/src/Writer/PHPClassWriter.php
@@ -1,13 +1,14 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Writer;
 
 use GoetasWebservices\Xsd\XsdToPhp\Php\ClassGenerator;
 use GoetasWebservices\Xsd\XsdToPhp\Php\PathGenerator\PathGenerator;
+use Laminas\Code\Generator\FileGenerator;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Laminas\Code\Generator\FileGenerator;
 
 class PHPClassWriter implements LoggerAwareInterface
 {
@@ -33,8 +34,8 @@ class PHPClassWriter implements LoggerAwareInterface
             $fileGen->setFilename($path);
             $fileGen->setClass($item);
             $fileGen->write();
-            $this->logger->debug(sprintf("Written PHP class file %s", $path));
+            $this->logger->debug(sprintf('Written PHP class file %s', $path));
         }
-        $this->logger->info(sprintf("Written %s STUB classes", count($items)));
+        $this->logger->info(sprintf('Written %s STUB classes', count($items)));
     }
 }

--- a/src/Writer/PHPWriter.php
+++ b/src/Writer/PHPWriter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Writer;
 
 use GoetasWebservices\Xsd\XsdToPhp\Php\ClassGenerator;
@@ -27,8 +28,8 @@ class PHPWriter extends Writer implements LoggerAwareInterface
      */
     public function write(array $items)
     {
-        while($item = array_pop($items)) {
-            if($generator = $this->generator->generate($item)) {
+        while ($item = array_pop($items)) {
+            if ($generator = $this->generator->generate($item)) {
                 $this->classWriter->write([$generator]);
             }
         }

--- a/src/Writer/Writer.php
+++ b/src/Writer/Writer.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Writer;
 
 abstract class Writer
 {
-    public abstract function write(array $items);
+    abstract public function write(array $items);
 }

--- a/tests/AbstractGenerator.php
+++ b/tests/AbstractGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests;
 
 use Composer\Autoload\ClassLoader;
@@ -14,8 +15,8 @@ use JMS\Serializer\Handler\HandlerRegistryInterface;
 
 abstract class AbstractGenerator
 {
-    protected $targetNs = array();
-    protected $aliases = array();
+    protected $targetNs = [];
+    protected $aliases = [];
 
     protected $phpDir;
     protected $jmsDir;
@@ -25,7 +26,7 @@ abstract class AbstractGenerator
 
     private $loader;
 
-    public function __construct(array $targetNs, array $aliases = array(), $tmp = null)
+    public function __construct(array $targetNs, array $aliases = [], $tmp = null)
     {
         $tmp = $tmp ?: sys_get_temp_dir();
 
@@ -40,16 +41,17 @@ abstract class AbstractGenerator
 
         $this->loader = new ClassLoader();
         foreach ($this->targetNs as $phpNs) {
-            $this->loader->addPsr4($phpNs . "\\", $this->phpDir . "/" . $this->slug($phpNs));
+            $this->loader->addPsr4($phpNs . '\\', $this->phpDir . '/' . $this->slug($phpNs));
         }
     }
 
     private static function delTree($dir)
     {
-        $files = array_diff(scandir($dir), array('.', '..'));
+        $files = array_diff(scandir($dir), ['.', '..']);
         foreach ($files as $file) {
             (is_dir("$dir/$file")) ? self::delTree("$dir/$file") : unlink("$dir/$file");
         }
+
         return rmdir($dir);
     }
 
@@ -71,9 +73,9 @@ abstract class AbstractGenerator
     public function cleanDirectories()
     {
         foreach ($this->targetNs as $phpNs) {
-            $phpDir = $this->phpDir . "/" . $this->slug($phpNs);
-            $jmsDir = $this->jmsDir . "/" . $this->slug($phpNs);
-            $validationDir = $this->validationDir . "/" . $this->slug($phpNs);
+            $phpDir = $this->phpDir . '/' . $this->slug($phpNs);
+            $jmsDir = $this->jmsDir . '/' . $this->slug($phpNs);
+            $validationDir = $this->validationDir . '/' . $this->slug($phpNs);
 
             foreach ([$phpDir, $jmsDir, $validationDir] as $dir) {
                 if (is_dir($dir)) {
@@ -86,7 +88,7 @@ abstract class AbstractGenerator
         }
     }
 
-    public function buildSerializer($callback = null, array $metadataDirs = array())
+    public function buildSerializer($callback = null, array $metadataDirs = [])
     {
         $serializerBuilder = \JMS\Serializer\SerializerBuilder::create();
         $serializerBuilder->configureHandlers(function (HandlerRegistryInterface $h) use ($callback, $serializerBuilder) {
@@ -97,11 +99,11 @@ abstract class AbstractGenerator
         });
 
         foreach ($this->targetNs as $phpNs) {
-            $metadataDirs[$phpNs] = $this->jmsDir . "/" . $this->slug($phpNs);
+            $metadataDirs[$phpNs] = $this->jmsDir . '/' . $this->slug($phpNs);
         }
 
         foreach ($metadataDirs as $php => $dir) {
-            if (!is_dir($dir)){
+            if (!is_dir($dir)) {
                 mkdir($dir, 0777, true);
             }
             $serializerBuilder->addMetadataDir($dir, $php);
@@ -113,6 +115,7 @@ abstract class AbstractGenerator
     public function registerAutoloader()
     {
         $this->loader->register();
+
         return $this->loader;
     }
 
@@ -126,9 +129,9 @@ abstract class AbstractGenerator
      */
     protected function writePHP(array $items)
     {
-        $paths = array();
+        $paths = [];
         foreach ($this->targetNs as $phpNs) {
-            $paths[$phpNs . "\\"] = $this->phpDir . "/" . $this->slug($phpNs);
+            $paths[$phpNs . '\\'] = $this->phpDir . '/' . $this->slug($phpNs);
         }
 
         $pathGenerator = new PhpPsr4PathGenerator($paths);
@@ -143,9 +146,9 @@ abstract class AbstractGenerator
      */
     protected function writeJMS(array $items)
     {
-        $paths = array();
+        $paths = [];
         foreach ($this->targetNs as $phpNs) {
-            $paths[$phpNs . "\\"] = $this->jmsDir . "/" . $this->slug($phpNs);
+            $paths[$phpNs . '\\'] = $this->jmsDir . '/' . $this->slug($phpNs);
         }
 
         $pathGenerator = new JmsPsr4PathGenerator($paths);
@@ -159,9 +162,9 @@ abstract class AbstractGenerator
      */
     protected function writeValidation(array $items)
     {
-        $paths = array();
+        $paths = [];
         foreach ($this->targetNs as $phpNs) {
-            $paths[$phpNs . "\\"] = $this->validationDir;
+            $paths[$phpNs . '\\'] = $this->validationDir;
         }
 
         $pathGenerator = new JmsPsr4PathGenerator($paths);

--- a/tests/Converter/AbstractXsdConverterTest.php
+++ b/tests/Converter/AbstractXsdConverterTest.php
@@ -1,13 +1,12 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Converter;
 
 use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
 
 class AbstractXsdConverterTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
-     *
      * @var AbstractConverter
      */
     protected $converter;
@@ -21,7 +20,7 @@ class AbstractXsdConverterTest extends \PHPUnit_Framework_TestCase
     {
         $f = function () {
         };
-        $this->converter->addAliasMap('http://www.example.com', "myType", $f);
+        $this->converter->addAliasMap('http://www.example.com', 'myType', $f);
 
         $handlers = \PHPUnit_Framework_Assert::readAttribute($this->converter, 'typeAliases');
 

--- a/tests/Converter/JMS/Xsd2JmsBase.php
+++ b/tests/Converter/JMS/Xsd2JmsBase.php
@@ -1,20 +1,19 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Converter\JMS;
 
+use GoetasWebservices\XML\XSDReader\SchemaReader;
 use GoetasWebservices\Xsd\XsdToPhp\Jms\YamlConverter;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
-use GoetasWebservices\XML\XSDReader\SchemaReader;
 
 abstract class Xsd2JmsBase extends \PHPUnit_Framework_TestCase
 {
     /**
-     *
      * @var YamlConverter
      */
     protected $converter;
 
     /**
-     *
      * @var SchemaReader
      */
     protected $reader;
@@ -22,17 +21,16 @@ abstract class Xsd2JmsBase extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->converter = new YamlConverter(new ShortNamingStrategy());
-        $this->converter->addNamespace('http://www.example.com', "Example");
+        $this->converter->addNamespace('http://www.example.com', 'Example');
 
         $this->reader = new SchemaReader();
     }
 
     protected function getClasses($xml)
     {
-
         $schema = $this->reader->readString($xml);
-        return $this->converter->convert(array($schema));
 
+        return $this->converter->convert([$schema]);
     }
 
     public function getBaseTypeConversions()
@@ -42,7 +40,6 @@ abstract class Xsd2JmsBase extends \PHPUnit_Framework_TestCase
             ['xs:date', 'DateTime', 'GoetasWebservices\\Xsd\\XsdToPhp\\XMLSchema\\Date'],
         ];
     }
-
 
     public function getPrimitiveTypeConversions()
     {

--- a/tests/Converter/JMS/Xsd2JmsElementTest.php
+++ b/tests/Converter/JMS/Xsd2JmsElementTest.php
@@ -139,79 +139,63 @@ class Xsd2PhpElementTest extends Xsd2JmsBase
             ';
         $classes = $this->getClasses($xsd);
 
-        $expected = array(
-            'Example\\Root\\RootAType' =>
-                array(
-                    'Example\\Root\\RootAType' =>
-                        array(
-                            'properties' =>
-                                array(
-                                    'child' =>
-                                        array(
-                                            'expose' => true,
-                                            'access_type' => 'public_method',
-                                            'serialized_name' => 'child',
-                                            'accessor' =>
-                                                array(
-                                                    'getter' => 'getChild',
-                                                    'setter' => 'setChild',
-                                                ),
-                                            'xml_list' =>
-                                                array(
-                                                    'inline' => true,
-                                                    'entry_name' => 'child',
-                                                ),
-                                            'type' => 'array<Example\\ChildType>',
-                                        ),
-                                    'childRoot' =>
-                                        array(
-                                            'expose' => true,
-                                            'access_type' => 'public_method',
-                                            'serialized_name' => 'childRoot',
-                                            'xml_element' =>
-                                                array(
-                                                    'namespace' => 'http://www.example.com',
-                                                ),
-                                            'accessor' =>
-                                                array(
-                                                    'getter' => 'getChildRoot',
-                                                    'setter' => 'setChildRoot',
-                                                ),
-                                            'type' => 'Example\\ChildType',
-                                        ),
-                                ),
-                        ),
-                ),
-            'Example\\Root' =>
-                array(
-                    'Example\\Root' =>
-                        array(
-                            'xml_root_name' => 'ns-8ece61d2:root',
-                            'xml_root_namespace' => 'http://www.example.com',
-                        ),
-                ),
-            'Example\\ChildType' =>
-                array(
-                    'Example\\ChildType' =>
-                        array(
-                            'properties' =>
-                                array(
-                                    'id' =>
-                                        array(
-                                            'expose' => true,
-                                            'access_type' => 'public_method',
-                                            'serialized_name' => 'id',
-                                            'accessor' =>
-                                                array(
-                                                    'getter' => 'getId',
-                                                    'setter' => 'setId',
-                                                ),
-                                            'type' => 'string',
-                                        ),
-                                ),
-                        ),
-                ),
-        );
+        $expected = [
+            'Example\\Root\\RootAType' => [
+                'Example\\Root\\RootAType' => [
+                    'properties' => [
+                        'child' => [
+                            'expose' => true,
+                            'access_type' => 'public_method',
+                            'serialized_name' => 'child',
+                            'accessor' => [
+                                'getter' => 'getChild',
+                                'setter' => 'setChild',
+                            ],
+                            'xml_list' => [
+                                'inline' => true,
+                                'entry_name' => 'child',
+                            ],
+                            'type' => 'array<Example\\ChildType>',
+                        ],
+                        'childRoot' => [
+                            'expose' => true,
+                            'access_type' => 'public_method',
+                            'serialized_name' => 'childRoot',
+                            'xml_element' => [
+                                'namespace' => 'http://www.example.com',
+                            ],
+                            'accessor' => [
+                                'getter' => 'getChildRoot',
+                                'setter' => 'setChildRoot',
+                            ],
+                            'type' => 'Example\\ChildType',
+                        ],
+                    ],
+                ],
+            ],
+            'Example\\Root' => [
+                'Example\\Root' => [
+                    'xml_root_name' => 'ns-8ece61d2:root',
+                    'xml_root_namespace' => 'http://www.example.com',
+                ],
+            ],
+            'Example\\ChildType' => [
+                'Example\\ChildType' => [
+                    'properties' => [
+                        'id' => [
+                            'expose' => true,
+                            'access_type' => 'public_method',
+                            'serialized_name' => 'id',
+                            'accessor' => [
+                                'getter' => 'getId',
+                                'setter' => 'setId',
+                            ],
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $classes);
     }
@@ -243,75 +227,60 @@ class Xsd2PhpElementTest extends Xsd2JmsBase
             ';
         $classes = $this->getClasses($xsd);
 
-        $expected = array(
-            'Example\\Root\\RootAType' =>
-                array(
-                    'Example\\Root\\RootAType' =>
-                        array(
-                            'properties' =>
-                                array(
-                                    'child' =>
-                                        array(
-                                            'expose' => true,
-                                            'access_type' => 'public_method',
-                                            'serialized_name' => 'child',
-                                            'accessor' =>
-                                                array(
-                                                    'getter' => 'getChild',
-                                                    'setter' => 'setChild',
-                                                ),
-                                            'xml_list' =>
-                                                array(
-                                                    'inline' => true,
-                                                    'entry_name' => 'child',
-                                                ),
-                                            'type' => 'array<Example\\ChildType>',
-                                        ),
-                                    'childRoot' =>
-                                        array(
-                                            'expose' => true,
-                                            'access_type' => 'public_method',
-                                            'serialized_name' => 'childRoot',
-                                            'accessor' =>
-                                                array(
-                                                    'getter' => 'getChildRoot',
-                                                    'setter' => 'setChildRoot',
-                                                ),
-                                            'type' => 'Example\\ChildType',
-                                        ),
-                                ),
-                        ),
-                ),
-            'Example\\Root' =>
-                array(
-                    'Example\\Root' =>
-                        array(
-                            'xml_root_name' => 'ns-8ece61d2:root',
-                            'xml_root_namespace' => 'http://www.example.com',
-                        ),
-                ),
-            'Example\\ChildType' =>
-                array(
-                    'Example\\ChildType' =>
-                        array(
-                            'properties' =>
-                                array(
-                                    'id' =>
-                                        array(
-                                            'expose' => true,
-                                            'access_type' => 'public_method',
-                                            'serialized_name' => 'id',
-                                            'accessor' =>
-                                                array(
-                                                    'getter' => 'getId',
-                                                    'setter' => 'setId',
-                                                ),
-                                            'type' => 'string',
-                                        ),
-                                ),
-                        ),
-                ),
-        );
+        $expected = [
+            'Example\\Root\\RootAType' => [
+                'Example\\Root\\RootAType' => [
+                    'properties' => [
+                        'child' => [
+                            'expose' => true,
+                            'access_type' => 'public_method',
+                            'serialized_name' => 'child',
+                            'accessor' => [
+                                'getter' => 'getChild',
+                                'setter' => 'setChild',
+                            ],
+                            'xml_list' => [
+                                'inline' => true,
+                                'entry_name' => 'child',
+                            ],
+                            'type' => 'array<Example\\ChildType>',
+                        ],
+                        'childRoot' => [
+                            'expose' => true,
+                            'access_type' => 'public_method',
+                            'serialized_name' => 'childRoot',
+                            'accessor' => [
+                                'getter' => 'getChildRoot',
+                                'setter' => 'setChildRoot',
+                            ],
+                            'type' => 'Example\\ChildType',
+                        ],
+                    ],
+                ],
+            ],
+            'Example\\Root' => [
+                'Example\\Root' => [
+                    'xml_root_name' => 'ns-8ece61d2:root',
+                    'xml_root_namespace' => 'http://www.example.com',
+                ],
+            ],
+            'Example\\ChildType' => [
+                'Example\\ChildType' => [
+                    'properties' => [
+                        'id' => [
+                            'expose' => true,
+                            'access_type' => 'public_method',
+                            'serialized_name' => 'id',
+                            'accessor' => [
+                                'getter' => 'getId',
+                                'setter' => 'setId',
+                            ],
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ];
 
         $this->assertEquals($expected, $classes);
     }
@@ -338,23 +307,23 @@ class Xsd2PhpElementTest extends Xsd2JmsBase
         $this->assertCount(1, $classes);
 
         $this->assertEquals(
-            array(
-                'Example\\ChildType' => array(
-                    'Example\\ChildType' => array(
-                        'properties' => array(
-                            'nsValue' => array(
+            [
+                'Example\\ChildType' => [
+                    'Example\\ChildType' => [
+                        'properties' => [
+                            'nsValue' => [
                                 'expose' => true,
                                 'access_type' => 'public_method',
                                 'serialized_name' => 'ns.value',
-                                'accessor' => array(
+                                'accessor' => [
                                     'getter' => 'getNsValue',
-                                    'setter' => 'setNsValue'
-                                ),
-                                'type' => 'string'
-                            )
-                        )
-                    )
-                )
-            ), $classes);
+                                    'setter' => 'setNsValue',
+                                ],
+                                'type' => 'string',
+                            ],
+                        ],
+                    ],
+                ],
+            ], $classes);
     }
 }

--- a/tests/Converter/JMS/Xsd2JmsElementTest.php
+++ b/tests/Converter/JMS/Xsd2JmsElementTest.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Converter\JMS;
 
 class Xsd2PhpElementTest extends Xsd2JmsBase
 {
-
     /**
      * @dataProvider getPrimitiveTypeConversions
      */
@@ -19,27 +19,8 @@ class Xsd2PhpElementTest extends Xsd2JmsBase
 
         $this->converter->setUseCdata(true);
         $classes = $this->getClasses($xml);
-        $this->assertCount(1, $classes);
 
-        $this->assertEquals(
-            array(
-                'Example\ElementOne' => array(
-                    'xml_root_name' => 'ns-8ece61d2:element-one',
-                    'xml_root_namespace' => 'http://www.example.com',
-                    'properties' => array(
-                        '__value' => array(
-                            'expose' => true,
-                            'xml_value' => true,
-                            'access_type' => 'public_method',
-                            'accessor' => array(
-                                'getter' => 'value',
-                                'setter' => 'value'
-                            ),
-                            'type' => $phpName
-                        )
-                    )
-                )
-            ), $classes['Example\ElementOne']);
+        $this->assertCount(0, $classes);
     }
 
     /**
@@ -57,30 +38,7 @@ class Xsd2PhpElementTest extends Xsd2JmsBase
 
         $this->converter->setUseCdata(false);
         $classes = $this->getClasses($xml);
-        $this->assertCount(1, $classes);
-
-        $this->assertEquals(
-            array(
-                'Example\ElementOne' => array(
-                    'xml_root_name' => 'ns-8ece61d2:element-one',
-                    'xml_root_namespace' => 'http://www.example.com',
-                    'properties' => array(
-                        '__value' => array(
-                            'expose' => true,
-                            'xml_value' => true,
-                            'access_type' => 'public_method',
-                            'accessor' => array(
-                                'getter' => 'value',
-                                'setter' => 'value'
-                            ),
-                            'xml_element' => array(
-                                'cdata' => false
-                            ),
-                            'type' => $phpName
-                        )
-                    )
-                )
-            ), $classes['Example\ElementOne']);
+        $this->assertCount(0, $classes);
     }
 
     /**
@@ -96,27 +54,7 @@ class Xsd2PhpElementTest extends Xsd2JmsBase
                </xs:schema>
             ';
         $classes = $this->getClasses($xml);
-        $this->assertCount(1, $classes);
-
-        $this->assertEquals(
-            array(
-                'Example\ElementOne' => array(
-                    'xml_root_name' => 'ns-8ece61d2:element-one',
-                    'xml_root_namespace' => 'http://www.example.com',
-                    'properties' => array(
-                        '__value' => array(
-                            'expose' => true,
-                            'xml_value' => true,
-                            'access_type' => 'public_method',
-                            'accessor' => array(
-                                'getter' => 'value',
-                                'setter' => 'value'
-                            ),
-                            'type' => $phpName
-                        )
-                    )
-                )
-            ), $classes['Example\ElementOne']);
+        $this->assertCount(0, $classes);
     }
 
     /**
@@ -136,27 +74,7 @@ class Xsd2PhpElementTest extends Xsd2JmsBase
             ';
 
         $classes = $this->getClasses($xml);
-        $this->assertCount(1, $classes);
-
-        $this->assertEquals(
-            array(
-                'Example\\ElementOne' => array(
-                    'xml_root_name' => 'ns-8ece61d2:element-one',
-                    'xml_root_namespace' => 'http://www.example.com',
-                    'properties' => array(
-                        '__value' => array(
-                            'expose' => true,
-                            'xml_value' => true,
-                            'access_type' => 'public_method',
-                            'accessor' => array(
-                                'getter' => 'value',
-                                'setter' => 'value'
-                            ),
-                            'type' => $phpName
-                        )
-                    )
-                )
-            ), $classes['Example\ElementOne']);
+        $this->assertCount(0, $classes);
     }
 
     /**
@@ -172,25 +90,7 @@ class Xsd2PhpElementTest extends Xsd2JmsBase
             ';
 
         $classes = $this->getClasses($xml);
-        $this->assertCount(1, $classes);
-
-        $this->assertEquals(array(
-            'Example\\ElementOne' => array(
-                'xml_root_name' => 'ns-8ece61d2:element-one',
-                'xml_root_namespace' => 'http://www.example.com',
-                'properties' => array(
-                    '__value' => array(
-                        'expose' => true,
-                        'xml_value' => true,
-                        'access_type' => 'public_method',
-                        'accessor' => array(
-                            'getter' => 'value',
-                            'setter' => 'value',
-                        ),
-                        'type' => $jmsType,
-                    ),
-                ))
-        ), $classes['Example\ElementOne']);
+        $this->assertCount(0, $classes);
     }
 
     /**
@@ -209,28 +109,7 @@ class Xsd2PhpElementTest extends Xsd2JmsBase
             ';
 
         $classes = $this->getClasses($xml);
-        $this->assertCount(1, $classes);
-
-        $this->assertEquals(array(
-            'Example\\ElementOne' => array(
-                'xml_root_name' => 'ns-8ece61d2:element-one',
-                'xml_root_namespace' => 'http://www.example.com',
-                'properties' => array(
-                    '__value' => array(
-                        'expose' => true,
-                        'xml_value' => true,
-                        'access_type' => 'public_method',
-                        'accessor' => array(
-                            'getter' => 'value',
-                            'setter' => 'value',
-                        ),
-                        'type' => $jmsType,
-                    ),
-                ),
-
-            )
-        ), $classes['Example\ElementOne']);
-
+        $this->assertCount(0, $classes);
     }
 
     public function testUnqualifiedNsQualifiedElement()
@@ -261,57 +140,77 @@ class Xsd2PhpElementTest extends Xsd2JmsBase
         $classes = $this->getClasses($xsd);
 
         $expected = array(
-            'Example\\Root' => array(
-                'Example\\Root' => array(
-                    'xml_root_name' => 'ns-8ece61d2:root',
-                    'xml_root_namespace' => 'http://www.example.com',
-                    'properties' => array(
-                        'child' => array(
-                            'expose' => true,
-                            'access_type' => 'public_method',
-                            'serialized_name' => 'child',
-                            'accessor' => array(
-                                'getter' => 'getChild',
-                                'setter' => 'setChild',
-                            ),
-                            'xml_list' => array(
-                                'inline' => true,
-                                'entry_name' => 'child',
-                            ),
-                            'type' => 'array<Example\\ChildType>',
+            'Example\\Root\\RootAType' =>
+                array(
+                    'Example\\Root\\RootAType' =>
+                        array(
+                            'properties' =>
+                                array(
+                                    'child' =>
+                                        array(
+                                            'expose' => true,
+                                            'access_type' => 'public_method',
+                                            'serialized_name' => 'child',
+                                            'accessor' =>
+                                                array(
+                                                    'getter' => 'getChild',
+                                                    'setter' => 'setChild',
+                                                ),
+                                            'xml_list' =>
+                                                array(
+                                                    'inline' => true,
+                                                    'entry_name' => 'child',
+                                                ),
+                                            'type' => 'array<Example\\ChildType>',
+                                        ),
+                                    'childRoot' =>
+                                        array(
+                                            'expose' => true,
+                                            'access_type' => 'public_method',
+                                            'serialized_name' => 'childRoot',
+                                            'xml_element' =>
+                                                array(
+                                                    'namespace' => 'http://www.example.com',
+                                                ),
+                                            'accessor' =>
+                                                array(
+                                                    'getter' => 'getChildRoot',
+                                                    'setter' => 'setChildRoot',
+                                                ),
+                                            'type' => 'Example\\ChildType',
+                                        ),
+                                ),
                         ),
-                        'childRoot' => array(
-                            'expose' => true,
-                            'access_type' => 'public_method',
-                            'serialized_name' => 'childRoot',
-                            'accessor' => array(
-                                'getter' => 'getChildRoot',
-                                'setter' => 'setChildRoot',
-                            ),
-                            'type' => 'Example\\ChildType',
-                            'xml_element' => array(
-                                'namespace' => 'http://www.example.com',
-                            ),
-                        ),
-                    ),
                 ),
-            ),
-            'Example\\ChildType' => array(
-                'Example\\ChildType' => array(
-                    'properties' => array(
-                        'id' => array(
-                            'expose' => true,
-                            'access_type' => 'public_method',
-                            'serialized_name' => 'id',
-                            'accessor' => array(
-                                'getter' => 'getId',
-                                'setter' => 'setId',
-                            ),
-                            'type' => 'string',
+            'Example\\Root' =>
+                array(
+                    'Example\\Root' =>
+                        array(
+                            'xml_root_name' => 'ns-8ece61d2:root',
+                            'xml_root_namespace' => 'http://www.example.com',
                         ),
-                    ),
                 ),
-            ),
+            'Example\\ChildType' =>
+                array(
+                    'Example\\ChildType' =>
+                        array(
+                            'properties' =>
+                                array(
+                                    'id' =>
+                                        array(
+                                            'expose' => true,
+                                            'access_type' => 'public_method',
+                                            'serialized_name' => 'id',
+                                            'accessor' =>
+                                                array(
+                                                    'getter' => 'getId',
+                                                    'setter' => 'setId',
+                                                ),
+                                            'type' => 'string',
+                                        ),
+                                ),
+                        ),
+                ),
         );
 
         $this->assertEquals($expected, $classes);
@@ -345,54 +244,73 @@ class Xsd2PhpElementTest extends Xsd2JmsBase
         $classes = $this->getClasses($xsd);
 
         $expected = array(
-            'Example\\Root' => array(
-                'Example\\Root' => array(
-                    'xml_root_name' => 'ns-8ece61d2:root',
-                    'xml_root_namespace' => 'http://www.example.com',
-                    'properties' => array(
-                        'child' => array(
-                            'expose' => true,
-                            'access_type' => 'public_method',
-                            'serialized_name' => 'child',
-                            'accessor' => array(
-                                'getter' => 'getChild',
-                                'setter' => 'setChild',
-                            ),
-                            'xml_list' => array(
-                                'inline' => true,
-                                'entry_name' => 'child',
-                            ),
-                            'type' => 'array<Example\\ChildType>',
+            'Example\\Root\\RootAType' =>
+                array(
+                    'Example\\Root\\RootAType' =>
+                        array(
+                            'properties' =>
+                                array(
+                                    'child' =>
+                                        array(
+                                            'expose' => true,
+                                            'access_type' => 'public_method',
+                                            'serialized_name' => 'child',
+                                            'accessor' =>
+                                                array(
+                                                    'getter' => 'getChild',
+                                                    'setter' => 'setChild',
+                                                ),
+                                            'xml_list' =>
+                                                array(
+                                                    'inline' => true,
+                                                    'entry_name' => 'child',
+                                                ),
+                                            'type' => 'array<Example\\ChildType>',
+                                        ),
+                                    'childRoot' =>
+                                        array(
+                                            'expose' => true,
+                                            'access_type' => 'public_method',
+                                            'serialized_name' => 'childRoot',
+                                            'accessor' =>
+                                                array(
+                                                    'getter' => 'getChildRoot',
+                                                    'setter' => 'setChildRoot',
+                                                ),
+                                            'type' => 'Example\\ChildType',
+                                        ),
+                                ),
                         ),
-                        'childRoot' => array(
-                            'expose' => true,
-                            'access_type' => 'public_method',
-                            'serialized_name' => 'childRoot',
-                            'accessor' => array(
-                                'getter' => 'getChildRoot',
-                                'setter' => 'setChildRoot',
-                            ),
-                            'type' => 'Example\\ChildType',
-                        ),
-                    ),
                 ),
-            ),
-            'Example\\ChildType' => array(
-                'Example\\ChildType' => array(
-                    'properties' => array(
-                        'id' => array(
-                            'expose' => true,
-                            'access_type' => 'public_method',
-                            'serialized_name' => 'id',
-                            'accessor' => array(
-                                'getter' => 'getId',
-                                'setter' => 'setId',
-                            ),
-                            'type' => 'string',
+            'Example\\Root' =>
+                array(
+                    'Example\\Root' =>
+                        array(
+                            'xml_root_name' => 'ns-8ece61d2:root',
+                            'xml_root_namespace' => 'http://www.example.com',
                         ),
-                    ),
                 ),
-            ),
+            'Example\\ChildType' =>
+                array(
+                    'Example\\ChildType' =>
+                        array(
+                            'properties' =>
+                                array(
+                                    'id' =>
+                                        array(
+                                            'expose' => true,
+                                            'access_type' => 'public_method',
+                                            'serialized_name' => 'id',
+                                            'accessor' =>
+                                                array(
+                                                    'getter' => 'getId',
+                                                    'setter' => 'setId',
+                                                ),
+                                            'type' => 'string',
+                                        ),
+                                ),
+                        ),
+                ),
         );
 
         $this->assertEquals($expected, $classes);

--- a/tests/Converter/JMS/Xsd2JmsGroupTest.php
+++ b/tests/Converter/JMS/Xsd2JmsGroupTest.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Converter\JMS;
 
 class Xsd2PhpGroupTest extends Xsd2JmsBase
 {
-
     public function testGroupArray()
     {
         $content = '
@@ -92,21 +92,21 @@ class Xsd2PhpGroupTest extends Xsd2JmsBase
         $classes = $this->getClasses($content);
         $this->assertCount(2, $classes);
         $this->assertEquals(
-            array(
-                'Example\\ComplexType1Type' => array(
-                    'properties' => array(
-                        'att' => array(
+            [
+                'Example\\ComplexType1Type' => [
+                    'properties' => [
+                        'att' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'att',
-                            'accessor' => array(
+                            'accessor' => [
                                 'getter' => 'getAtt',
-                                'setter' => 'setAtt'
-                            ),
+                                'setter' => 'setAtt',
+                            ],
                             'xml_attribute' => true,
-                            'type' => 'string'
-                        ),
-                        'string1' => array(
+                            'type' => 'string',
+                        ],
+                        'string1' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'string1',
@@ -115,28 +115,28 @@ class Xsd2PhpGroupTest extends Xsd2JmsBase
                                'namespace' => 'http://www.example.com'
                            ),
                             */
-                           'accessor' => array(
-                               'getter' => 'getString1',
-                               'setter' => 'setString1'
-                           ),
-                           'type' => 'string'
-                       ),
-                       'string2' => array(
-                           'expose' => true,
-                           'access_type' => 'public_method',
-                           'serialized_name' => 'string2',
-                           /*
+                            'accessor' => [
+                                'getter' => 'getString1',
+                                'setter' => 'setString1',
+                            ],
+                            'type' => 'string',
+                        ],
+                        'string2' => [
+                            'expose' => true,
+                            'access_type' => 'public_method',
+                            'serialized_name' => 'string2',
+                            /*
                            'xml_element' => array(
                                'namespace' => 'http://www.example.com'
                            ),
                            */
-                            'accessor' => array(
+                            'accessor' => [
                                 'getter' => 'getString2',
-                                'setter' => 'setString2'
-                            ),
-                            'type' => 'Example\\ComplexType1Type\\String2AType'
-                        ),
-                        'string3' => array(
+                                'setter' => 'setString2',
+                            ],
+                            'type' => 'Example\\ComplexType1Type\\String2AType',
+                        ],
+                        'string3' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'string3',
@@ -145,13 +145,13 @@ class Xsd2PhpGroupTest extends Xsd2JmsBase
                                 'namespace' => 'http://www.example.com'
                             ),
                             */
-                            'accessor' => array(
+                            'accessor' => [
                                 'getter' => 'getString3',
-                                'setter' => 'setString3'
-                            ),
-                            'type' => 'string'
-                        ),
-                        'string4' => array(
+                                'setter' => 'setString3',
+                            ],
+                            'type' => 'string',
+                        ],
+                        'string4' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'string4',
@@ -160,13 +160,13 @@ class Xsd2PhpGroupTest extends Xsd2JmsBase
                                 'namespace' => 'http://www.example.com'
                             ),
                             */
-                            'accessor' => array(
+                            'accessor' => [
                                 'getter' => 'getString4',
-                                'setter' => 'setString4'
-                            ),
-                            'type' => 'string'
-                        ),
-                        'string5' => array(
+                                'setter' => 'setString4',
+                            ],
+                            'type' => 'string',
+                        ],
+                        'string5' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'string5',
@@ -175,39 +175,38 @@ class Xsd2PhpGroupTest extends Xsd2JmsBase
                                 'namespace' => 'http://www.example.com'
                             ),
                             */
-                            'accessor' => array(
+                            'accessor' => [
                                 'getter' => 'getString5',
-                                'setter' => 'setString5'
-                            ),
-                            'type' => 'string'
-                        ),
-                    )
-                )
-            ), $classes['Example\\ComplexType1Type']);
-
+                                'setter' => 'setString5',
+                            ],
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ], $classes['Example\\ComplexType1Type']);
 
         $this->assertEquals(
-            array(
-                'Example\\ComplexType1Type\\String2AType' => array(
-                    'properties' => array(
-                        'string3' => array(
+            [
+                'Example\\ComplexType1Type\\String2AType' => [
+                    'properties' => [
+                        'string3' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'string3',
-                             /*
+                            /*
                             'xml_element' => array(
                                 'namespace' => 'http://www.example.com'
                             ),
                              */
-                            'accessor' => array(
+                            'accessor' => [
                                 'getter' => 'getString3',
-                                'setter' => 'setString3'
-                            ),
-                            'type' => 'string'
-                        )
-                    )
-                )
-            ), $classes['Example\\ComplexType1Type\\String2AType']);
+                                'setter' => 'setString3',
+                            ],
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ], $classes['Example\\ComplexType1Type\\String2AType']);
     }
 
     public function testSomeAnonymousWithRefs()
@@ -276,72 +275,72 @@ class Xsd2PhpGroupTest extends Xsd2JmsBase
         $this->assertCount(2, $classes);
 
         $this->assertEquals(
-            array(
-                'Example\\ComplexType1Type' => array(
-                    'properties' => array(
-                        'attribute2' => array(
+            [
+                'Example\\ComplexType1Type' => [
+                    'properties' => [
+                        'attribute2' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'attribute-2',
-                            'accessor' => array(
+                            'accessor' => [
                                 'getter' => 'getAttribute2',
-                                'setter' => 'setAttribute2'
-                            ),
+                                'setter' => 'setAttribute2',
+                            ],
                             'xml_attribute' => true,
-                            'type' => 'string'
-                        ),
-                        'complexType1El1' => array(
+                            'type' => 'string',
+                        ],
+                        'complexType1El1' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'complexType-1-el-1',
-                             /*
+                            /*
                             'xml_element' => array(
                                 'namespace' => 'http://www.example.com'
                             ),
                              */
-                            'accessor' => array(
+                            'accessor' => [
                                 'getter' => 'getComplexType1El1',
-                                'setter' => 'setComplexType1El1'
-                            ),
-                            'type' => 'string'
-                        )
-                    )
-                )
-            ), $classes['Example\\ComplexType1Type']);
+                                'setter' => 'setComplexType1El1',
+                            ],
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ], $classes['Example\\ComplexType1Type']);
 
         $this->assertEquals(
-            array(
-                'Example\\ComplexType2Type' => array(
-                    'properties' => array(
-                        'complexType2Att1' => array(
+            [
+                'Example\\ComplexType2Type' => [
+                    'properties' => [
+                        'complexType2Att1' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'complexType-2-att1',
-                            'accessor' => array(
+                            'accessor' => [
                                 'getter' => 'getComplexType2Att1',
-                                'setter' => 'setComplexType2Att1'
-                            ),
+                                'setter' => 'setComplexType2Att1',
+                            ],
                             'xml_attribute' => true,
-                            'type' => 'string'
-                        ),
-                        'complexType2El1' => array(
+                            'type' => 'string',
+                        ],
+                        'complexType2El1' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'complexType-2-el1',
-                             /*
+                            /*
                             'xml_element' => array(
                                 'namespace' => 'http://www.example.com'
                             ),
                              */
-                            'accessor' => array(
+                            'accessor' => [
                                 'getter' => 'getComplexType2El1',
-                                'setter' => 'setComplexType2El1'
-                            ),
-                            'type' => 'string'
-                        )
-                    )
-                )
-            ), $classes['Example\\ComplexType2Type']);
+                                'setter' => 'setComplexType2El1',
+                            ],
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ], $classes['Example\\ComplexType2Type']);
     }
 
     public function getMaxOccurs()
@@ -349,11 +348,11 @@ class Xsd2PhpGroupTest extends Xsd2JmsBase
         return [
             [
                 null,
-                false
+                false,
             ],
             [
                 '1',
-                false
+                false,
             ],
             /*
             ['2', true],
@@ -388,32 +387,32 @@ class Xsd2PhpGroupTest extends Xsd2JmsBase
         $this->assertCount(2, $classes);
 
         $this->assertEquals(
-            array(
-                'Example\\ComplexType1Type' => array(
-                    'properties' => array(
-                        'strings' => array(
+            [
+                'Example\\ComplexType1Type' => [
+                    'properties' => [
+                        'strings' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'strings',
-                             /*
+                            /*
                             'xml_element' => array(
                                 'namespace' => 'http://www.example.com'
                             ),
                              */
-                            'accessor' => array(
+                            'accessor' => [
                                 'getter' => 'getStrings',
-                                'setter' => 'setStrings'
-                            ),
+                                'setter' => 'setStrings',
+                            ],
                             'type' => 'array<string>',
-                            'xml_list' => array(
+                            'xml_list' => [
                                 'inline' => false,
                                 'entry_name' => 'string',
-                                'skip_when_empty' => false
-                            )
-                        )
-                    )
-                )
-            ), $classes['Example\\ComplexType1Type']);
+                                'skip_when_empty' => false,
+                            ],
+                        ],
+                    ],
+                ],
+            ], $classes['Example\\ComplexType1Type']);
     }
 
     /**
@@ -425,7 +424,7 @@ class Xsd2PhpGroupTest extends Xsd2JmsBase
              <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
                 <xs:complexType name="complexType-1">
                      <xs:sequence>
-                            <xs:element ' . ($max !== null ? (' maxOccurs="' . $max . '"') : "") . ' name="complexType-1-el-1" type="xs:string"/>
+                            <xs:element ' . ($max !== null ? (' maxOccurs="' . $max . '"') : '') . ' name="complexType-1-el-1" type="xs:string"/>
                      </xs:sequence>
                 </xs:complexType>
             </xs:schema>
@@ -434,27 +433,27 @@ class Xsd2PhpGroupTest extends Xsd2JmsBase
         $this->assertCount(1, $classes);
 
         $this->assertEquals(
-            array(
-                'Example\\ComplexType1Type' => array(
-                    'properties' => array(
-                        'complexType1El1' => array(
+            [
+                'Example\\ComplexType1Type' => [
+                    'properties' => [
+                        'complexType1El1' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'complexType-1-el-1',
-                             /*
+                            /*
                             'xml_element' => array(
                                 'namespace' => 'http://www.example.com'
                             ),
                              */
-                            'accessor' => array(
+                            'accessor' => [
                                 'getter' => 'getComplexType1El1',
-                                'setter' => 'setComplexType1El1'
-                            ),
-                            'type' => 'string'
-                        )
-                    )
-                )
-            ), $classes['Example\\ComplexType1Type']);
+                                'setter' => 'setComplexType1El1',
+                            ],
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ], $classes['Example\\ComplexType1Type']);
     }
 
     public function testGeneralParts()
@@ -506,108 +505,108 @@ class Xsd2PhpGroupTest extends Xsd2JmsBase
         $this->assertCount(1, $classes);
 
         $this->assertEquals(
-            array(
-                'Example\\ComplexType1Type' => array(
-                    'properties' => array(
-                        'attribute1' => array(
+            [
+                'Example\\ComplexType1Type' => [
+                    'properties' => [
+                        'attribute1' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'attribute-1',
-                            'accessor' => array(
+                            'accessor' => [
                                 'getter' => 'getAttribute1',
-                                'setter' => 'setAttribute1'
-                            ),
+                                'setter' => 'setAttribute1',
+                            ],
                             'xml_attribute' => true,
-                            'type' => 'string'
-                        ),
-                        'attribute2' => array(
+                            'type' => 'string',
+                        ],
+                        'attribute2' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'attribute-2',
-                            'accessor' => array(
+                            'accessor' => [
                                 'getter' => 'getAttribute2',
-                                'setter' => 'setAttribute2'
-                            ),
+                                'setter' => 'setAttribute2',
+                            ],
                             'xml_attribute' => true,
-                            'type' => 'string'
-                        ),
-                        'attributeGroup1Att1' => array(
+                            'type' => 'string',
+                        ],
+                        'attributeGroup1Att1' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'attributeGroup-1-att-1',
-                            'accessor' => array(
+                            'accessor' => [
                                 'getter' => 'getAttributeGroup1Att1',
-                                'setter' => 'setAttributeGroup1Att1'
-                            ),
+                                'setter' => 'setAttributeGroup1Att1',
+                            ],
                             'xml_attribute' => true,
-                            'type' => 'string'
-                        ),
-                        'attributeGroup2Att2' => array(
+                            'type' => 'string',
+                        ],
+                        'attributeGroup2Att2' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'attributeGroup-2-att-2',
-                            'accessor' => array(
+                            'accessor' => [
                                 'getter' => 'getAttributeGroup2Att2',
-                                'setter' => 'setAttributeGroup2Att2'
-                            ),
+                                'setter' => 'setAttributeGroup2Att2',
+                            ],
                             'xml_attribute' => true,
-                            'type' => 'string'
-                        ),
-                        'group1El1' => array(
+                            'type' => 'string',
+                        ],
+                        'group1El1' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'group-1-el-1',
-//                            'xml_element' => array(
-//                                'namespace' => 'http://www.example.com'
-//                            ),
-                            'accessor' => array(
+                            //                            'xml_element' => array(
+                            //                                'namespace' => 'http://www.example.com'
+                            //                            ),
+                            'accessor' => [
                                 'getter' => 'getGroup1El1',
-                                'setter' => 'setGroup1El1'
-                            ),
-                            'type' => 'string'
-                        ),
-                        'group2El1' => array(
+                                'setter' => 'setGroup1El1',
+                            ],
+                            'type' => 'string',
+                        ],
+                        'group2El1' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'group-2-el-1',
-//                            'xml_element' => array(
-//                                'namespace' => 'http://www.example.com'
-//                            ),
-                            'accessor' => array(
+                            //                            'xml_element' => array(
+                            //                                'namespace' => 'http://www.example.com'
+                            //                            ),
+                            'accessor' => [
                                 'getter' => 'getGroup2El1',
-                                'setter' => 'setGroup2El1'
-                            ),
-                            'type' => 'string'
-                        ),
-                        'element1' => array(
+                                'setter' => 'setGroup2El1',
+                            ],
+                            'type' => 'string',
+                        ],
+                        'element1' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'element-1',
-                            'xml_element' => array(
-                                'namespace' => 'http://www.example.com'
-                            ),
-                            'accessor' => array(
+                            'xml_element' => [
+                                'namespace' => 'http://www.example.com',
+                            ],
+                            'accessor' => [
                                 'getter' => 'getElement1',
-                                'setter' => 'setElement1'
-                            ),
-                            'type' => 'string'
-                        ),
-                        'complexType1El1' => array(
+                                'setter' => 'setElement1',
+                            ],
+                            'type' => 'string',
+                        ],
+                        'complexType1El1' => [
                             'expose' => true,
                             'access_type' => 'public_method',
                             'serialized_name' => 'complexType-1-el-1',
-//                            'xml_element' => array(
-//                                'namespace' => 'http://www.example.com'
-//                            ),
-                            'accessor' => array(
+                            //                            'xml_element' => array(
+                            //                                'namespace' => 'http://www.example.com'
+                            //                            ),
+                            'accessor' => [
                                 'getter' => 'getComplexType1El1',
-                                'setter' => 'setComplexType1El1'
-                            ),
-                            'type' => 'string'
-                        )
-                    )
-                )
-            ), $classes['Example\\ComplexType1Type']);
+                                'setter' => 'setComplexType1El1',
+                            ],
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ], $classes['Example\\ComplexType1Type']);
     }
 
     public function testListOfRestriction()

--- a/tests/Converter/JMS/Xsd2JmsGroupTest.php
+++ b/tests/Converter/JMS/Xsd2JmsGroupTest.php
@@ -237,16 +237,17 @@ class Xsd2PhpGroupTest extends Xsd2JmsBase
             </xs:schema>
             ';
         $classes = $this->getClasses($content);
+
         $this->assertCount(4, $classes);
 
         $this->assertArrayHasKey('Example\AddressBookType', $classes);
         $this->assertArrayHasKey('Example\Contacts', $classes);
-        $this->assertArrayHasKey('Example\Contacts\ContactAType', $classes);
+        $this->assertArrayHasKey('Example\Contacts\ContactsAType\ContactAType', $classes);
         $this->assertArrayHasKey('Example\Contacts\ContactsAType', $classes);
         $this->assertArrayHasKey('Example\AddressBookType', $classes);
 
         $book = $classes['Example\AddressBookType']['Example\AddressBookType'];
-        $this->assertSame('array<Example\Contacts\ContactAType>', $book['properties']['contacts']['type']);
+        $this->assertSame('array<Example\Contacts\ContactsAType\ContactAType>', $book['properties']['contacts']['type']);
     }
 
     public function testSomeInheritance()
@@ -258,7 +259,7 @@ class Xsd2PhpGroupTest extends Xsd2JmsBase
                      <xs:sequence>
                             <xs:element name="complexType-1-el-1" type="xs:string"/>
                      </xs:sequence>
-                </xs:complexType>
+                </xs:complexType>ContactsAType
                 <xs:complexType name="complexType-2">
                      <xs:complexContent>
                         <xs:extension base="ex:complexType-1">
@@ -502,7 +503,7 @@ class Xsd2PhpGroupTest extends Xsd2JmsBase
             ';
         $classes = $this->getClasses($content);
 
-        $this->assertCount(2, $classes);
+        $this->assertCount(1, $classes);
 
         $this->assertEquals(
             array(
@@ -607,25 +608,6 @@ class Xsd2PhpGroupTest extends Xsd2JmsBase
                     )
                 )
             ), $classes['Example\\ComplexType1Type']);
-        $this->assertEquals(
-            array(
-                'Example\\Element1' => array(
-                    'xml_root_name' => 'ns-8ece61d2:element-1',
-                    'xml_root_namespace' => 'http://www.example.com',
-                    'properties' => array(
-                        '__value' => array(
-                            'expose' => true,
-                            'xml_value' => true,
-                            'access_type' => 'public_method',
-                            'accessor' => array(
-                                'getter' => 'value',
-                                'setter' => 'value'
-                            ),
-                            'type' => 'string'
-                        )
-                    )
-                )
-            ), $classes['Example\\Element1']);
     }
 
     public function testListOfRestriction()

--- a/tests/Converter/PHP/Xsd2PhpBase.php
+++ b/tests/Converter/PHP/Xsd2PhpBase.php
@@ -1,20 +1,19 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Converter\PHP;
 
+use GoetasWebservices\XML\XSDReader\SchemaReader;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
 use GoetasWebservices\Xsd\XsdToPhp\Php\PhpConverter;
-use GoetasWebservices\XML\XSDReader\SchemaReader;
 
 abstract class Xsd2PhpBase extends \PHPUnit_Framework_TestCase
 {
     /**
-     *
      * @var PhpConverter
      */
     protected $converter;
 
     /**
-     *
      * @var SchemaReader
      */
     protected $reader;
@@ -22,17 +21,16 @@ abstract class Xsd2PhpBase extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->converter = new PhpConverter(new ShortNamingStrategy());
-        $this->converter->addNamespace('http://www.example.com', "Example");
+        $this->converter->addNamespace('http://www.example.com', 'Example');
 
         $this->reader = new SchemaReader();
     }
 
     protected function getClasses($xml)
     {
-
         $schema = $this->reader->readString($xml);
-        return $this->converter->convert(array($schema));
 
+        return $this->converter->convert([$schema]);
     }
 
     public function getBaseTypeConversions()
@@ -41,7 +39,6 @@ abstract class Xsd2PhpBase extends \PHPUnit_Framework_TestCase
             ['xs:dateTime', 'DateTime'],
         ];
     }
-
 
     public function getPrimitiveTypeConversions()
     {

--- a/tests/Converter/PHP/Xsd2PhpElementTest.php
+++ b/tests/Converter/PHP/Xsd2PhpElementTest.php
@@ -19,22 +19,7 @@ class Xsd2PhpElementTest extends Xsd2PhpBase
 
         $classes = $this->converter->convert(array($this->reader->readString($content)));
 
-        $this->assertCount(1, $classes);
-        $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $classes['Example\ElementOne']);
-        $this->assertEquals('Example', $classes['Example\ElementOne']->getNamespace());
-        $this->assertEquals('ElementOne', $classes['Example\ElementOne']->getName());
-
-        $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $classes['Example\ElementOne']->getExtends());
-
-        $this->assertCount(0, $classes['Example\ElementOne']->getProperties());
-        //$this->assertArrayHasKey("__value", $classes['Example\ElementOne']->getProperties());
-
-        //$property = $classes['Example\ElementOne']->getProperty('__value');
-        //$this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPProperty', $property);
-
-        //$this->assertEquals('protected', $property->getVisibility());
-        //$this->assertEquals('', $property->getType()->getNamespace());
-        //$this->assertEquals($phpName, $property->getType()->getName());
+        $this->assertCount(0, $classes);
     }
 
     /**
@@ -54,24 +39,7 @@ class Xsd2PhpElementTest extends Xsd2PhpBase
             ';
         $classes = $this->converter->convert(array($this->reader->readString($content)));
 
-        $this->assertCount(1, $classes);
-        $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $classes['Example\ElementOne']);
-        $this->assertEquals('Example', $classes['Example\ElementOne']->getNamespace());
-        $this->assertEquals('ElementOne', $classes['Example\ElementOne']->getName());
-
-        $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $classes['Example\ElementOne']->getExtends());
-
-        $this->assertCount(0, $classes['Example\ElementOne']->getProperties());
-
-        /*
-        $this->assertArrayHasKey("__value", $classes['Example\ElementOne']->getProperties());
-
-        $property = $classes['Example\ElementOne']->getProperty('__value');
-        $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPProperty', $property);
-
-        $this->assertEquals('', $property->getType()->getNamespace());
-        $this->assertEquals($phpName, $property->getType()->getName());
-        */
+        $this->assertCount(0, $classes);
     }
 
     /**
@@ -87,18 +55,7 @@ class Xsd2PhpElementTest extends Xsd2PhpBase
             ';
         $classes = $this->converter->convert(array($this->reader->readString($content)));
 
-        $this->assertCount(1, $classes);
-        $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $classes['Example\ElementOne']);
-        $this->assertEquals('Example', $classes['Example\ElementOne']->getNamespace());
-        $this->assertEquals('ElementOne', $classes['Example\ElementOne']->getName());
-
-        $this->assertCount(0, $classes['Example\ElementOne']->getProperties());
-
-        $extension = $classes['Example\ElementOne']->getExtends();
-        $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $extension);
-
-        $this->assertEquals('', $extension->getNamespace());
-        $this->assertEquals($phpName, $extension->getName());
+        $this->assertCount(0, $classes);
     }
 
     /**
@@ -118,17 +75,7 @@ class Xsd2PhpElementTest extends Xsd2PhpBase
             ';
         $classes = $this->converter->convert(array($this->reader->readString($content)));
 
-        $this->assertCount(1, $classes);
-        $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $classes['Example\ElementOne']);
-        $this->assertEquals('Example', $classes['Example\ElementOne']->getNamespace());
-        $this->assertEquals('ElementOne', $classes['Example\ElementOne']->getName());
 
-        $this->assertCount(0, $classes['Example\ElementOne']->getProperties());
-
-        $extension = $classes['Example\ElementOne']->getExtends();
-        $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $extension);
-
-        $this->assertEquals('', $extension->getNamespace());
-        $this->assertEquals($phpName, $extension->getName());
+        $this->assertCount(0, $classes);
     }
 }

--- a/tests/Converter/PHP/Xsd2PhpElementTest.php
+++ b/tests/Converter/PHP/Xsd2PhpElementTest.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Converter\PHP;
 
 class Xsd2PhpElementTest extends Xsd2PhpBase
 {
-
     /**
      * @dataProvider getPrimitiveTypeConversions
      */
@@ -17,7 +17,7 @@ class Xsd2PhpElementTest extends Xsd2PhpBase
                </xs:schema>
             ';
 
-        $classes = $this->converter->convert(array($this->reader->readString($content)));
+        $classes = $this->converter->convert([$this->reader->readString($content)]);
 
         $this->assertCount(0, $classes);
     }
@@ -37,7 +37,7 @@ class Xsd2PhpElementTest extends Xsd2PhpBase
                 </xs:element>
                </xs:schema>
             ';
-        $classes = $this->converter->convert(array($this->reader->readString($content)));
+        $classes = $this->converter->convert([$this->reader->readString($content)]);
 
         $this->assertCount(0, $classes);
     }
@@ -53,7 +53,7 @@ class Xsd2PhpElementTest extends Xsd2PhpBase
                 </xs:element>
                </xs:schema>
             ';
-        $classes = $this->converter->convert(array($this->reader->readString($content)));
+        $classes = $this->converter->convert([$this->reader->readString($content)]);
 
         $this->assertCount(0, $classes);
     }
@@ -73,8 +73,7 @@ class Xsd2PhpElementTest extends Xsd2PhpBase
                 </xs:element>
                </xs:schema>
             ';
-        $classes = $this->converter->convert(array($this->reader->readString($content)));
-
+        $classes = $this->converter->convert([$this->reader->readString($content)]);
 
         $this->assertCount(0, $classes);
     }

--- a/tests/Converter/PHP/Xsd2PhpGroupTest.php
+++ b/tests/Converter/PHP/Xsd2PhpGroupTest.php
@@ -147,7 +147,7 @@ class Xsd2PhpGroupTest extends Xsd2PhpBase
 
         $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $book = $classes['Example\AddressBookType']);
         $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $contacts = $classes['Example\Contacts']);
-        $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $contactsContact = $classes['Example\Contacts\ContactAType']);
+        $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $contactsContact = $classes['Example\Contacts\ContactsAType\ContactAType']);
         $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $contactsType = $classes['Example\Contacts\ContactsAType']);
         $this->assertSame($book->getProperty('contacts')->getType()->getArg()->getType()->getFullName(), $contactsContact->getFullName());
     }
@@ -418,10 +418,10 @@ class Xsd2PhpGroupTest extends Xsd2PhpBase
             ';
         $classes = $this->getClasses($content);
 
-        $this->assertCount(2, $classes);
+        $this->assertCount(1, $classes);
 
         $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $complexType1 = $classes['Example\ComplexType1Type']);
-        $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $element1 = $classes['Example\Element1']);
+
 
 
         //$complexType1

--- a/tests/Converter/PHP/Xsd2PhpGroupTest.php
+++ b/tests/Converter/PHP/Xsd2PhpGroupTest.php
@@ -1,11 +1,11 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Converter\PHP;
 
 use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClassOf;
 
 class Xsd2PhpGroupTest extends Xsd2PhpBase
 {
-
     public function testAutoDiscoveryTraits()
     {
         $content = '
@@ -112,7 +112,6 @@ class Xsd2PhpGroupTest extends Xsd2PhpBase
 
         $a1Prop = $complexType1->getProperty('att');
         $this->assertSame('\string', $a1Prop->getType()->getFullName());
-
     }
 
     public function testSomeAnonymousWithRefs()
@@ -143,7 +142,6 @@ class Xsd2PhpGroupTest extends Xsd2PhpBase
         $classes = $this->getClasses($content);
 
         $this->assertCount(4, $classes);
-
 
         $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $book = $classes['Example\AddressBookType']);
         $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $contacts = $classes['Example\Contacts']);
@@ -242,7 +240,7 @@ class Xsd2PhpGroupTest extends Xsd2PhpBase
             if (($p = $tt->isSimpleType()) && ($t = $p->getType())) {
                 $typ = $t->getPhpType();
             }
-            self::assertSame("float", $typ);
+            self::assertSame('float', $typ);
         }
 
         $complexType = $classes['Example\ElementsCtType'];
@@ -259,7 +257,7 @@ class Xsd2PhpGroupTest extends Xsd2PhpBase
             if (($p = $tt->isSimpleType()) && ($t = $p->getType())) {
                 $typ = $t->getPhpType();
             }
-            self::assertSame("float", $typ);
+            self::assertSame('float', $typ);
         }
     }
 
@@ -302,7 +300,6 @@ class Xsd2PhpGroupTest extends Xsd2PhpBase
         $this->assertEquals('complexType2El1', $property->getName());
         $this->assertEquals('', $property->getType()->getNamespace());
         $this->assertEquals('string', $property->getType()->getName());
-
     }
 
     public function getMaxOccurs()
@@ -348,7 +345,6 @@ class Xsd2PhpGroupTest extends Xsd2PhpBase
 
         $this->assertEquals('', $typePropType->getNamespace());
         $this->assertEquals('string', $typePropType->getName());
-
     }
 
     /**
@@ -360,7 +356,7 @@ class Xsd2PhpGroupTest extends Xsd2PhpBase
              <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema">
                 <xs:complexType name="complexType-1">
                      <xs:sequence>
-                            <xs:element ' . ($max !== null ? (' maxOccurs="' . $max . '"') : "") . ' name="complexType-1-el-1" type="xs:string"/>
+                            <xs:element ' . ($max !== null ? (' maxOccurs="' . $max . '"') : '') . ' name="complexType-1-el-1" type="xs:string"/>
                      </xs:sequence>
                 </xs:complexType>
             </xs:schema>
@@ -368,9 +364,7 @@ class Xsd2PhpGroupTest extends Xsd2PhpBase
         $classes = $this->getClasses($content);
         $this->assertCount(1, $classes);
         $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $complexType1 = $classes['Example\ComplexType1Type']);
-
     }
-
 
     public function testGeneralParts()
     {
@@ -422,8 +416,6 @@ class Xsd2PhpGroupTest extends Xsd2PhpBase
 
         $this->assertInstanceOf('GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass', $complexType1 = $classes['Example\ComplexType1Type']);
 
-
-
         //$complexType1
         $property = $complexType1->getProperty('attribute1');
         $this->assertEquals('attribute1', $property->getName());
@@ -439,7 +431,5 @@ class Xsd2PhpGroupTest extends Xsd2PhpBase
         $this->assertEquals('complexType1El1', $property->getName());
         $this->assertEquals('', $property->getType()->getNamespace());
         $this->assertEquals('string', $property->getType()->getName());
-
     }
-
 }

--- a/tests/Converter/Validator/Xsd2ValidatorTest.php
+++ b/tests/Converter/Validator/Xsd2ValidatorTest.php
@@ -2,9 +2,9 @@
 
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Converter\Validator;
 
+use GoetasWebservices\XML\XSDReader\SchemaReader;
 use GoetasWebservices\Xsd\XsdToPhp\Jms\YamlValidatorConverter;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
-use GoetasWebservices\XML\XSDReader\SchemaReader;
 
 class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -19,26 +19,28 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
     protected $reader;
 
     /**
-     * Set up converter and reader properties
+     * Set up converter and reader properties.
      */
     public function setUp()
     {
         $this->converter = new YamlValidatorConverter(new ShortNamingStrategy());
-        $this->converter->addNamespace('http://www.example.com', "Example");
+        $this->converter->addNamespace('http://www.example.com', 'Example');
 
         $this->reader = new SchemaReader();
     }
 
     /**
-     * Return classes coverted through YamlValidatorConverter
+     * Return classes coverted through YamlValidatorConverter.
      *
      * @param string $xml
+     *
      * @return array
      */
     protected function getClasses($xml)
     {
         $schema = $this->reader->readString($xml);
-        return $this->converter->convert(array($schema));
+
+        return $this->converter->convert([$schema]);
     }
 
     public function getRestrictionsValidations()
@@ -57,33 +59,33 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                                 '201115',
                                 '203015',
                                 '213150',
-                                '225105'
+                                '225105',
                             ],
-                            'groups' => ['xsd_rules']
-                        ]
-                    ]
-                ]
+                            'groups' => ['xsd_rules'],
+                        ],
+                    ],
+                ],
             ],
-//            // fractionDigits / Regex
-//            //                / Range
-//            [
-//                '<xs:fractionDigits value="2"/>',
-//                [
-//                    [
-//                        'Regex' => '/^\-?(\\d+\.\\d{2})|\\d*$/',
-//                    ]
-//                ]
-//            ],
-//            // fractionDigits / Regex
-//            //                / Range
-//            [
-//                '<xs:totalDigits value="4"/>',
-//                [
-//                    [
-//                        'Regex' => '/^\-?[\\d]{0,4}$/',
-//                    ],
-//                ]
-//            ],
+            //            // fractionDigits / Regex
+            //            //                / Range
+            //            [
+            //                '<xs:fractionDigits value="2"/>',
+            //                [
+            //                    [
+            //                        'Regex' => '/^\-?(\\d+\.\\d{2})|\\d*$/',
+            //                    ]
+            //                ]
+            //            ],
+            //            // fractionDigits / Regex
+            //            //                / Range
+            //            [
+            //                '<xs:totalDigits value="4"/>',
+            //                [
+            //                    [
+            //                        'Regex' => '/^\-?[\\d]{0,4}$/',
+            //                    ],
+            //                ]
+            //            ],
             // length / Length(min/max)
             [
                 '<xs:length value="12"/>',
@@ -92,10 +94,10 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                         'Length' => [
                             'min' => 12,
                             'max' => 12,
-                            'groups' => ['xsd_rules']
-                        ]
-                    ]
-                ]
+                            'groups' => ['xsd_rules'],
+                        ],
+                    ],
+                ],
             ],
             // maxLength / Length(max)
             [
@@ -104,10 +106,10 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                     [
                         'Length' => [
                             'max' => 100,
-                            'groups' => ['xsd_rules']
-                        ]
-                    ]
-                ]
+                            'groups' => ['xsd_rules'],
+                        ],
+                    ],
+                ],
             ],
             // minLength / Length(min)
             [
@@ -116,10 +118,10 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                     [
                         'Length' => [
                             'min' => 3,
-                            'groups' => ['xsd_rules']
-                        ]
-                    ]
-                ]
+                            'groups' => ['xsd_rules'],
+                        ],
+                    ],
+                ],
             ],
             // pattern / Regex
             [
@@ -128,10 +130,10 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                     [
                         'Regex' => [
                             'pattern' => '~\\([0-9]{2}\\)\\s[0-9]{4}-[0-9]{4,5}~',
-                            'groups' => ['xsd_rules']
-                        ]
-                    ]
-                ]
+                            'groups' => ['xsd_rules'],
+                        ],
+                    ],
+                ],
             ],
             // maxExclusive / LessThan
             [
@@ -140,10 +142,10 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                     [
                         'LessThan' => [
                             'value' => 50,
-                            'groups' => ['xsd_rules']
-                        ]
-                    ]
-                ]
+                            'groups' => ['xsd_rules'],
+                        ],
+                    ],
+                ],
             ],
             // maxInclusive / LessThanOrEqual
             [
@@ -152,10 +154,10 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                     [
                         'LessThanOrEqual' => [
                             'value' => 60,
-                            'groups' => ['xsd_rules']
-                        ]
-                    ]
-                ]
+                            'groups' => ['xsd_rules'],
+                        ],
+                    ],
+                ],
             ],
             // minExclusive / GreaterThan
             [
@@ -164,10 +166,10 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                     [
                         'GreaterThan' => [
                             'value' => 10,
-                            'groups' => ['xsd_rules']
-                        ]
-                    ]
-                ]
+                            'groups' => ['xsd_rules'],
+                        ],
+                    ],
+                ],
             ],
             // minInclusive / GreaterThanOrEqual
             [
@@ -176,11 +178,11 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                     [
                         'GreaterThanOrEqual' => [
                             'value' => 10,
-                            'groups' => ['xsd_rules']
-                        ]
-                    ]
-                ]
-            ]
+                            'groups' => ['xsd_rules'],
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 
@@ -214,15 +216,12 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
             [
                 'Example\\TypeOneType' => [
                     'properties' => [
-                        'elementOne' => $ymlValidations
-                    ]
-                ]
+                        'elementOne' => $ymlValidations,
+                    ],
+                ],
             ], $classes['Example\TypeOneType']);
     }
 
-    /**
-     *
-     */
     public function testComplexTypeWithRequired()
     {
         $content = '
@@ -245,18 +244,15 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                         'column1' => [
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
             ], $classes['Example\\ComplexType1Type']);
     }
 
-    /**
-     *
-     */
     public function testComplexTypeWithNoRequired()
     {
         $content = '
@@ -306,21 +302,21 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                             [
                                 [
                                     'NotNull' => [
-                                        'groups' => ['xsd_rules']
-                                    ]
-                                ]
+                                        'groups' => ['xsd_rules'],
+                                    ],
+                                ],
                             ]
-                        )
-                    ]
-                ]
+                        ),
+                    ],
+                ],
             ], $classes['Example\\ComplexType1Type'], print_r([array_merge(
             $ymlValidations,
             [
                 [
                     'NotNull' => [
-                        'groups' => ['xsd_rules']
-                    ]
-                ]
+                        'groups' => ['xsd_rules'],
+                    ],
+                ],
             ]
         ), $classes['Example\\ComplexType1Type']], 1));
     }
@@ -353,15 +349,12 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
             [
                 'Example\\ComplexType1Type' => [
                     'properties' => [
-                        'column1' => $ymlValidations
-                    ]
-                ]
+                        'column1' => $ymlValidations,
+                    ],
+                ],
             ], $classes['Example\\ComplexType1Type']);
     }
 
-    /**
-     *
-     */
     public function testComplexTypeWithArray_1()
     {
         $content = '
@@ -384,19 +377,16 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                         'column1' => [
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
                             ],
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ], $classes['Example\\ComplexType1Type'], print_r($classes['Example\\ComplexType1Type'], 1));
     }
 
-    /**
-     *
-     */
-    function testComplexTypeWithArray_2()
+    public function testComplexTypeWithArray_2()
     {
         $content = '
              <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema"  xmlns:ex="http://www.example.com">
@@ -418,19 +408,16 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                         'column1' => [
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
                             ],
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ], $classes['Example\\ComplexType1Type']);
     }
 
-    /**
-     *
-     */
-    function testComplexTypeWithArray_3()
+    public function testComplexTypeWithArray_3()
     {
         $content = '
              <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema"  xmlns:ex="http://www.example.com">
@@ -446,12 +433,8 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $classes);
     }
 
-    /**
-     *
-     */
     public function testComplexTypeWithElementArrayRestriction()
     {
-
         $content = '
              <xs:schema targetNamespace="http://www.example.com" xmlns:xs="http://www.w3.org/2001/XMLSchema"  xmlns:ex="http://www.example.com">
                 <xs:complexType name="complexType-2">
@@ -480,8 +463,8 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                         'protocols' => [
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
                             ],
                             [
                                 'All' => [
@@ -490,27 +473,22 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                                         [
                                             'Length' => [
                                                 'min' => 1,
-                                            ]
-
+                                            ],
                                         ],
                                         [
                                             'Length' => [
                                                 'max' => 12,
-                                            ]
+                                            ],
                                         ],
-                                    ]
-                                ]
+                                    ],
+                                ],
                             ],
-
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ], $classes['Example\\ComplexType2Type'], print_r($classes['Example\\ComplexType2Type'], 1));
     }
 
-    /**
-     *
-     */
     public function testComplexTypeWithArrayNestedRestriction()
     {
         $content = '
@@ -547,8 +525,8 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                         'protocolNumber' => [
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
                             ],
                             [
                                 'All' => [
@@ -557,21 +535,19 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                                         [
                                             'Length' => [
                                                 'min' => 1,
-                                            ]
-
+                                            ],
                                         ],
                                         [
                                             'Length' => [
                                                 'max' => 12,
-                                            ]
-                                        ]
-                                    ]
-                                ]
+                                            ],
+                                        ],
+                                    ],
+                                ],
                             ],
-
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ], $classes['Example\\ComplexType1Type\\ProtocolsAType'], print_r($classes['Example\\ComplexType1Type\\ProtocolsAType'], 1));
 
         $this->assertEquals(
@@ -579,31 +555,27 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                 'Example\\ComplexType1Type' => [
                     'properties' => [
                         'protocols' => [
-
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
                             ],
                             [
                                 'Count' => [
                                     'min' => 1,
                                     'max' => 30,
-                                    'groups' => ['xsd_rules']
-                                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
                             ],
                             [
-                                'Valid' => null
+                                'Valid' => null,
                             ],
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ], $classes['Example\\ComplexType1Type'], print_r($classes['Example\\ComplexType1Type'], 1));
     }
 
-    /**
-     *
-     */
     public function testComplexTypeWithElementArrayRestrictionNoRequired()
     {
         $content = '
@@ -632,11 +604,11 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                 'Example\\ComplexType2Type' => [
                     'properties' => [
                         'protocols' => [
-//                            [
-//                                'Count' => [
-//                                    'max' => 10
-//                                ]
-//                            ],
+                            //                            [
+                            //                                'Count' => [
+                            //                                    'max' => 10
+                            //                                ]
+                            //                            ],
                             [
                                 'All' => [
                                     'groups' => ['xsd_rules'],
@@ -644,26 +616,22 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                                         [
                                             'Length' => [
                                                 'min' => 1,
-                                            ]
-
+                                            ],
                                         ],
                                         [
                                             'Length' => [
                                                 'max' => 12,
-                                            ]
-                                        ]
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
             ], $classes['Example\\ComplexType2Type']);
     }
 
-    /**
-     *
-     */
     public function testComplexTypeWithArrayNestedRestrictionNoRequired_1()
     {
         $content = '
@@ -705,20 +673,19 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                                         [
                                             'Length' => [
                                                 'min' => 1,
-                                            ]
-
+                                            ],
                                         ],
                                         [
                                             'Length' => [
                                                 'max' => 12,
-                                            ]
-                                        ]
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
             ], $classes['Example\\ComplexType1Type\\ProtocolsAType']);
 
         $this->assertEquals(
@@ -726,30 +693,26 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                 'Example\\ComplexType1Type' => [
                     'properties' => [
                         'protocols' => [
-
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
                             ],
                             [
                                 'Count' => [
                                     'max' => 30,
-                                    'groups' => ['xsd_rules']
-                                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
                             ],
                             [
-                                'Valid' => null
-                            ]
-                        ]
-                    ]
-                ]
+                                'Valid' => null,
+                            ],
+                        ],
+                    ],
+                ],
             ], $classes['Example\\ComplexType1Type']);
     }
 
-    /**
-     *
-     */
     public function testComplexTypeWithArrayNestedRestrictionNoRequired_2()
     {
         $content = '
@@ -784,7 +747,6 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                 'Example\\ComplexType1Type\\ProtocolsAType' => [
                     'properties' => [
                         'protocolNumber' => [
-
                             [
                                 'All' => [
                                     'groups' => ['xsd_rules'],
@@ -792,20 +754,19 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                                         [
                                             'Length' => [
                                                 'min' => 1,
-                                            ]
-
+                                            ],
                                         ],
                                         [
                                             'Length' => [
                                                 'max' => 12,
-                                            ]
-                                        ]
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
             ], $classes['Example\\ComplexType1Type\\ProtocolsAType']);
 
         $this->assertEquals(
@@ -816,21 +777,18 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                             [
                                 'Count' => [
                                     'max' => 30,
-                                    'groups' => ['xsd_rules']
-                                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
                             ],
                             [
-                                'Valid' => null
-                            ]
-                        ]
-                    ]
-                ]
+                                'Valid' => null,
+                            ],
+                        ],
+                    ],
+                ],
             ], $classes['Example\\ComplexType1Type']);
     }
 
-    /**
-     *
-     */
     public function testComplexTypeWithNestedComplexRestrictionRequired()
     {
         $content = '
@@ -868,15 +826,15 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                         'diagnostcs' => [
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
                             ],
                             [
-                                'Valid' => null
-                            ]
-                        ]
-                    ]
-                ]
+                                'Valid' => null,
+                            ],
+                        ],
+                    ],
+                ],
             ], $classes['Example\ComplexType1Type']);
 
         $this->assertEquals(
@@ -886,39 +844,34 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                         'table' => [
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
-                            ]
+                                    'groups' => ['xsd_rules'],
+                                ],
+                            ],
                         ],
                         'code' => [
                             [
                                 'Length' => [
                                     'min' => 1,
-                                    'groups' => ['xsd_rules']
-                                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
                             ],
                             [
                                 'Length' => [
                                     'max' => 10,
-                                    'groups' => ['xsd_rules']
-                                ]
-
+                                    'groups' => ['xsd_rules'],
+                                ],
                             ],
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
-
-                            ]
-                        ]
-                    ]
-                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
             ], $classes['Example\\ComplexType1Type\\DiagnostcsAType']);
     }
 
-    /**
-     *
-     */
     public function testComplexTypeWithArrayNestedComplexRestrictionRequired()
     {
         $content = '
@@ -962,21 +915,21 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                         'consult' => [
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
                             ],
                             [
                                 'Count' => [
                                     'min' => 1,
-                                    'groups' => ['xsd_rules']
-                                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
                             ],
                             [
-                                'Valid' => null
+                                'Valid' => null,
                             ],
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ], $classes['Example\\ComplexType1Type']);
 
         $this->assertEquals(
@@ -986,32 +939,31 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                         'table' => [
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
-                            ]
+                                    'groups' => ['xsd_rules'],
+                                ],
+                            ],
                         ],
                         'code' => [
                             [
                                 'Length' => [
                                     'min' => 1,
-                                    'groups' => ['xsd_rules']
-                                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
                             ],
                             [
                                 'Length' => [
                                     'max' => 10,
-                                    'groups' => ['xsd_rules']
-                                ]
-
+                                    'groups' => ['xsd_rules'],
+                                ],
                             ],
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
                             ],
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ], $classes['Example\\ComplexType1Type\\ConsultAType\\DiagnostcsAType']);
 
         $this->assertEquals(
@@ -1021,27 +973,23 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                         'diagnostcs' => [
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
                             ],
-//                            [
-//                                'Count' => [
-//                                    'min' => 1
-//                                ]
-//                            ],
+                            //                            [
+                            //                                'Count' => [
+                            //                                    'min' => 1
+                            //                                ]
+                            //                            ],
                             [
-                                'Valid' => null
+                                'Valid' => null,
                             ],
-
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ], $classes['Example\\ComplexType1Type\\ConsultAType']);
     }
 
-    /**
-     *
-     */
     public function testComplexTypeWithExtension_1()
     {
         $content = '
@@ -1078,33 +1026,33 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                         'lang' => [
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
-                            ]
+                                    'groups' => ['xsd_rules'],
+                                ],
+                            ],
                         ],
                         'address' => [
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
-                            ]
+                                    'groups' => ['xsd_rules'],
+                                ],
+                            ],
                         ],
                         'city' => [
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
-                            ]
+                                    'groups' => ['xsd_rules'],
+                                ],
+                            ],
                         ],
                         'country' => [
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
             ], $classes['Example\\FullpersoninfoType']);
 
         $this->assertEquals(
@@ -1114,19 +1062,19 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                         'firstname' => [
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
-                            ]
+                                    'groups' => ['xsd_rules'],
+                                ],
+                            ],
                         ],
                         'lastname' => [
                             [
                                 'NotNull' => [
-                                    'groups' => ['xsd_rules']
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
+                                    'groups' => ['xsd_rules'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
             ], $classes['Example\\PersoninfoType']);
     }
 }

--- a/tests/Converter/Validator/Xsd2ValidatorTest.php
+++ b/tests/Converter/Validator/Xsd2ValidatorTest.php
@@ -198,6 +198,11 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
                          </xs:restriction>
                     </xs:simpleType>
                 </xs:element>
+                <xs:complexType name="type-one">
+                    <xs:sequence>
+                        <xs:element ref="element-one" minOccurs="0"/>
+                    </xs:sequence>
+                </xs:complexType>
                </xs:schema>
             ';
 
@@ -207,12 +212,12 @@ class Xsd2ValidatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             [
-                'Example\\ElementOne' => [
+                'Example\\TypeOneType' => [
                     'properties' => [
-                        '__value' => $ymlValidations
+                        'elementOne' => $ymlValidations
                     ]
                 ]
-            ], $classes['Example\ElementOne']);
+            ], $classes['Example\TypeOneType']);
     }
 
     /**

--- a/tests/Generator.php
+++ b/tests/Generator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests;
 
 use GoetasWebservices\Xsd\XsdToPhp\Jms\YamlConverter;
@@ -31,6 +32,7 @@ class Generator extends AbstractGenerator
         $converter = new PhpConverter($this->namingStrategy);
         $this->setNamespaces($converter);
         $items = $converter->convert($schemas);
+
         return $items;
     }
 
@@ -39,6 +41,7 @@ class Generator extends AbstractGenerator
         $converter = new YamlConverter($this->namingStrategy);
         $this->setNamespaces($converter);
         $items = $converter->convert($schemas);
+
         return $items;
     }
 
@@ -47,6 +50,7 @@ class Generator extends AbstractGenerator
         $converter = new YamlValidatorConverter($this->namingStrategy);
         $this->setNamespaces($converter);
         $items = $converter->convert($schemas);
+
         return $items;
     }
 
@@ -57,7 +61,7 @@ class Generator extends AbstractGenerator
     {
         $builder = Validation::createValidatorBuilder();
 
-        foreach (glob($this->validationDir.'/*.yml') as $file) {
+        foreach (glob($this->validationDir . '/*.yml') as $file) {
             $builder->addYamlMapping($file);
         }
 

--- a/tests/Issues/I111/I111Test.php
+++ b/tests/Issues/I111/I111Test.php
@@ -1,16 +1,17 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Issues\I11;
 
 use GoetasWebservices\XML\XSDReader\SchemaReader;
 use GoetasWebservices\Xsd\XsdToPhp\Jms\YamlConverter;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
 
-class I111Test extends \PHPUnit_Framework_TestCase{
-
+class I111Test extends \PHPUnit_Framework_TestCase
+{
     public function testNamespace()
     {
         $reader = new SchemaReader();
-        $schema = $reader->readFile(__DIR__.'/data.xsd');
+        $schema = $reader->readFile(__DIR__ . '/data.xsd');
 
         $jmsConv = new YamlConverter(new ShortNamingStrategy());
         $jmsConv->addNamespace('http://www.example.com', 'Tst');

--- a/tests/Issues/I22/I22Test.php
+++ b/tests/Issues/I22/I22Test.php
@@ -1,16 +1,17 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Issues\I22;
 
 use GoetasWebservices\XML\XSDReader\SchemaReader;
 use GoetasWebservices\Xsd\XsdToPhp\Jms\YamlConverter;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
 
-class I22Test extends \PHPUnit_Framework_TestCase{
-
+class I22Test extends \PHPUnit_Framework_TestCase
+{
     public function testNamespace()
     {
         $reader = new SchemaReader();
-        $schema = $reader->readFile(__DIR__.'/data.xsd');
+        $schema = $reader->readFile(__DIR__ . '/data.xsd');
 
         $jmsConv = new YamlConverter(new ShortNamingStrategy());
         $jmsConv->addNamespace('http://www.example.com', 'XmlListTest');
@@ -18,7 +19,6 @@ class I22Test extends \PHPUnit_Framework_TestCase{
 
         $phpClasses = $jmsConv->convert([$schema]);
         $complexType = $phpClasses['XmlListTest\ComplexType1Type']['XmlListTest\ComplexType1Type'];
-
 
         $nestedElement = $complexType['properties']['elementList']['xml_list'];
         self::assertEquals('http://www.example2.com', $nestedElement['namespace']);

--- a/tests/Issues/I26/I26Test.php
+++ b/tests/Issues/I26/I26Test.php
@@ -11,7 +11,7 @@ class I26Test extends \PHPUnit_Framework_TestCase
     public function testSkipWhenEmptyOnOptionalAndRequiredLists()
     {
         $reader = new SchemaReader();
-        $schema = $reader->readFile(__DIR__.'/data.xsd');
+        $schema = $reader->readFile(__DIR__ . '/data.xsd');
 
         $yamlConverter = new YamlConverter(new ShortNamingStrategy());
         $yamlConverter->addNamespace('', 'NestedArrayTest');
@@ -24,5 +24,4 @@ class I26Test extends \PHPUnit_Framework_TestCase
         self::assertEquals(false, $required['xml_list']['skip_when_empty']);
         self::assertEquals(true, $optional['xml_list']['skip_when_empty']);
     }
-
 }

--- a/tests/Issues/I40/I40Test.php
+++ b/tests/Issues/I40/I40Test.php
@@ -3,23 +3,36 @@ namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Issues\I40;
 
 use GoetasWebservices\Xsd\XsdToPhp\Jms\YamlConverter;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
+use GoetasWebservices\Xsd\XsdToPhp\Php\ClassGenerator;
+use GoetasWebservices\Xsd\XsdToPhp\Php\PathGenerator\Psr4PathGenerator as PhpPsr4PathGenerator;
 use GoetasWebservices\Xsd\XsdToPhp\Php\PhpConverter;
 use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass;
 use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPProperty;
 use GoetasWebservices\XML\XSDReader\SchemaReader;
+use GoetasWebservices\Xsd\XsdToPhp\Writer\PHPClassWriter;
+use GoetasWebservices\Xsd\XsdToPhp\Writer\PHPWriter;
 
 class I40Test extends \PHPUnit_Framework_TestCase
 {
 
     public function testMissingClass()
     {
-
         $expectedItems = array(
             'Epa\\Schema\\AdditionalIdentifier',
             'Epa\\Schema\\AdditionalIdentifierType',
             'Epa\\Schema\\AdditionalIdentifierTypes',
             'Epa\\Schema\\AdditionalIdentifiers',
         );
+
+        /*
+         * FArray
+(
+
+
+    [2] => Epa\Schema\AdditionalIdentifier\AdditionalIdentifierTypeAType
+)
+
+         */
         $expectedItems = array_combine($expectedItems, $expectedItems);
 
         $reader = new SchemaReader();
@@ -29,7 +42,9 @@ class I40Test extends \PHPUnit_Framework_TestCase
         $yamlConv->addNamespace('', 'Epa\\Schema');
 
         $yamlItems = $yamlConv->convert([$schema]);
-        $this->assertCount(count($expectedItems), $yamlItems);
+        print_r(array_keys($yamlItems));
+//        print_r($yamlItems);
+//        $this->assertCount(count($expectedItems), $yamlItems);
         $this->assertEmpty(array_diff_key($expectedItems, $yamlItems));
 
         $phpConv = new PhpConverter(new ShortNamingStrategy());
@@ -53,5 +68,105 @@ class I40Test extends \PHPUnit_Framework_TestCase
         $phpType = $phpProperty->getType();
 
         $this->assertSame($yamlProperty['type'], $phpType->getFullName());
+    }
+
+    public function testDetectSimpleParents()
+    {
+        $expectedItems = array(
+            'Epa\\Schema\\AdditionalIdentifier',
+            'Epa\\Schema\\AdditionalIdentifierType',
+            'Epa\\Schema\\AdditionalIdentifierTypes',
+            'Epa\\Schema\\AdditionalIdentifiers',
+        );
+
+        $expectedItems = array_combine($expectedItems, $expectedItems);
+
+        $reader = new SchemaReader();
+        $schema = $reader->readFile(__DIR__ . '/data_nested.xsd');
+
+        $yamlConv = new YamlConverter(new ShortNamingStrategy());
+        $yamlConv->addNamespace('', 'Epa\\Schema');
+
+        $yamlItems = $yamlConv->convert([$schema]);
+        print_r($yamlItems);
+
+        $phpConv = new PhpConverter(new ShortNamingStrategy());
+        $phpConv->addNamespace('', 'Epa\\Schema');
+
+        $phpClasses = $phpConv->convert([$schema]);
+
+        $pathGenerator = new PhpPsr4PathGenerator(['Epa\\Schema' => __DIR__ . '/'. __FUNCTION__]);
+
+        $classWriter = new PHPClassWriter($pathGenerator);
+        $writer = new PHPWriter($classWriter, new ClassGenerator());
+        $writer->write($phpClasses);
+
+    }
+
+    public function testDetectSimpleParentsWithAttributes()
+    {
+        $expectedItems = array(
+            'Epa\\Schema\\AdditionalIdentifier',
+            'Epa\\Schema\\AdditionalIdentifierType',
+            'Epa\\Schema\\AdditionalIdentifierTypes',
+            'Epa\\Schema\\AdditionalIdentifiers',
+        );
+
+        $expectedItems = array_combine($expectedItems, $expectedItems);
+
+        $reader = new SchemaReader();
+        $schema = $reader->readFile(__DIR__ . '/data_nested_with_attributes.xsd');
+
+        $yamlConv = new YamlConverter(new ShortNamingStrategy());
+        $yamlConv->addNamespace('', 'Epa\\Schema');
+
+        $yamlItems = $yamlConv->convert([$schema]);
+
+        print_r($yamlItems);
+        $phpConv = new PhpConverter(new ShortNamingStrategy());
+        $phpConv->addNamespace('', 'Epa\\Schema');
+
+        $phpClasses = $phpConv->convert([$schema]);
+
+        $pathGenerator = new PhpPsr4PathGenerator(['Epa\\Schema' => __DIR__ . '/'. __FUNCTION__]);
+
+        $classWriter = new PHPClassWriter($pathGenerator);
+        $writer = new PHPWriter($classWriter, new ClassGenerator());
+        $writer->write($phpClasses);
+
+    }
+
+    public function testDetectSimpleParentsWithAttributesInTheMiddle()
+    {
+        $expectedItems = array(
+            'Epa\\Schema\\AdditionalIdentifier',
+            'Epa\\Schema\\AdditionalIdentifierType',
+            'Epa\\Schema\\AdditionalIdentifierTypes',
+            'Epa\\Schema\\AdditionalIdentifiers',
+        );
+
+        $expectedItems = array_combine($expectedItems, $expectedItems);
+
+        $reader = new SchemaReader();
+        $schema = $reader->readFile(__DIR__ . '/data_nested_with_attributes_in_the_middle.xsd');
+
+        $yamlConv = new YamlConverter(new ShortNamingStrategy());
+        $yamlConv->addNamespace('', 'Epa\\Schema');
+
+        $yamlItems = $yamlConv->convert([$schema]);
+
+        print_r($yamlItems);
+
+        $phpConv = new PhpConverter(new ShortNamingStrategy());
+        $phpConv->addNamespace('', 'Epa\\Schema');
+
+        $phpClasses = $phpConv->convert([$schema]);
+
+        $pathGenerator = new PhpPsr4PathGenerator(['Epa\\Schema' => __DIR__ . '/'. __FUNCTION__]);
+
+        $classWriter = new PHPClassWriter($pathGenerator);
+        $writer = new PHPWriter($classWriter, new ClassGenerator());
+        $writer->write($phpClasses);
+
     }
 }

--- a/tests/Issues/I40/I40Test.php
+++ b/tests/Issues/I40/I40Test.php
@@ -1,40 +1,16 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Issues\I40;
 
+use GoetasWebservices\XML\XSDReader\SchemaReader;
 use GoetasWebservices\Xsd\XsdToPhp\Jms\YamlConverter;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
-use GoetasWebservices\Xsd\XsdToPhp\Php\ClassGenerator;
-use GoetasWebservices\Xsd\XsdToPhp\Php\PathGenerator\Psr4PathGenerator as PhpPsr4PathGenerator;
 use GoetasWebservices\Xsd\XsdToPhp\Php\PhpConverter;
-use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass;
-use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPProperty;
-use GoetasWebservices\XML\XSDReader\SchemaReader;
-use GoetasWebservices\Xsd\XsdToPhp\Writer\PHPClassWriter;
-use GoetasWebservices\Xsd\XsdToPhp\Writer\PHPWriter;
 
 class I40Test extends \PHPUnit_Framework_TestCase
 {
-
-    public function testMissingClass()
+    public function testMissingClassZZ()
     {
-        $expectedItems = array(
-            'Epa\\Schema\\AdditionalIdentifier',
-            'Epa\\Schema\\AdditionalIdentifierType',
-            'Epa\\Schema\\AdditionalIdentifierTypes',
-            'Epa\\Schema\\AdditionalIdentifiers',
-        );
-
-        /*
-         * FArray
-(
-
-
-    [2] => Epa\Schema\AdditionalIdentifier\AdditionalIdentifierTypeAType
-)
-
-         */
-        $expectedItems = array_combine($expectedItems, $expectedItems);
-
         $reader = new SchemaReader();
         $schema = $reader->readFile(__DIR__ . '/data.xsd');
 
@@ -42,45 +18,115 @@ class I40Test extends \PHPUnit_Framework_TestCase
         $yamlConv->addNamespace('', 'Epa\\Schema');
 
         $yamlItems = $yamlConv->convert([$schema]);
-        print_r(array_keys($yamlItems));
-//        print_r($yamlItems);
-//        $this->assertCount(count($expectedItems), $yamlItems);
-        $this->assertEmpty(array_diff_key($expectedItems, $yamlItems));
+        $this->assertEquals([
+            'Epa\\Schema\\AdditionalIdentifiers' => [
+                'Epa\\Schema\\AdditionalIdentifiers' => [
+                    'xml_root_name' => 'additionalIdentifiers',
+                ],
+            ],
+            'Epa\\Schema\\AdditionalIdentifier' => [
+                'Epa\\Schema\\AdditionalIdentifier' => [
+                    'xml_root_name' => 'additionalIdentifier',
+                ],
+            ],
+            'Epa\\Schema\\AdditionalIdentifierType' => [
+                'Epa\\Schema\\AdditionalIdentifierType' => [
+                    'xml_root_name' => 'additionalIdentifierType',
+                ],
+            ],
+            'Epa\\Schema\\AdditionalIdentifierType\\AdditionalIdentifierTypeAType' => [
+                'Epa\\Schema\\AdditionalIdentifierType\\AdditionalIdentifierTypeAType' => [
+                    'properties' => [
+                        'id' => [
+                            'expose' => true,
+                            'access_type' => 'public_method',
+                            'serialized_name' => 'id',
+                            'accessor' => [
+                                'getter' => 'getId',
+                                'setter' => 'setId',
+                            ],
+                            'xml_attribute' => true,
+                            'type' => 'int',
+                        ],
+                    ],
+                ],
+            ],
+            'Epa\\Schema\\AdditionalIdentifier\\AdditionalIdentifierAType' => [
+                'Epa\\Schema\\AdditionalIdentifier\\AdditionalIdentifierAType' => [
+                    'properties' => [
+                        'additionalIdentifierType' => [
+                            'expose' => true,
+                            'access_type' => 'public_method',
+                            'serialized_name' => 'additionalIdentifierType',
+                            'accessor' => [
+                                'getter' => 'getAdditionalIdentifierType',
+                                'setter' => 'setAdditionalIdentifierType',
+                            ],
+                            'type' => 'Epa\\Schema\\AdditionalIdentifierType\\AdditionalIdentifierTypeAType',
+                        ],
+                    ],
+                ],
+            ],
+            'Epa\\Schema\\AdditionalIdentifiers\\AdditionalIdentifiersAType' => [
+                'Epa\\Schema\\AdditionalIdentifiers\\AdditionalIdentifiersAType' => [
+                    'properties' => [
+                        'additionalIdentifier' => [
+                            'expose' => true,
+                            'access_type' => 'public_method',
+                            'serialized_name' => 'additionalIdentifier',
+                            'accessor' => [
+                                'getter' => 'getAdditionalIdentifier',
+                                'setter' => 'setAdditionalIdentifier',
+                            ],
+                            'xml_list' => [
+                                'inline' => true,
+                                'entry_name' => 'additionalIdentifier',
+                            ],
+                            'type' => 'array<Epa\\Schema\\AdditionalIdentifier>',
+                        ],
+                    ],
+                ],
+            ],
+            'Epa\\Schema\\AdditionalIdentifierTypes' => [
+                'Epa\\Schema\\AdditionalIdentifierTypes' => [
+                    'xml_root_name' => 'additionalIdentifierTypes',
+                ],
+            ],
+            'Epa\\Schema\\AdditionalIdentifierTypes\\AdditionalIdentifierTypesAType' => [
+                'Epa\\Schema\\AdditionalIdentifierTypes\\AdditionalIdentifierTypesAType' => [
+                    'properties' => [
+                        'additionalIdentifierType' => [
+                            'expose' => true,
+                            'access_type' => 'public_method',
+                            'serialized_name' => 'additionalIdentifierType',
+                            'accessor' => [
+                                'getter' => 'getAdditionalIdentifierType',
+                                'setter' => 'setAdditionalIdentifierType',
+                            ],
+                            'xml_list' => [
+                                'inline' => true,
+                                'entry_name' => 'additionalIdentifierType',
+                            ],
+                            'type' => 'array<Epa\\Schema\\AdditionalIdentifierType>',
+                        ],
+                    ],
+                ],
+            ],
+        ], $yamlItems);
 
         $phpConv = new PhpConverter(new ShortNamingStrategy());
         $phpConv->addNamespace('', 'Epa\\Schema');
 
         $phpClasses = $phpConv->convert([$schema]);
 
-        $this->assertCount(count($expectedItems), $phpClasses);
-        $this->assertEmpty(array_diff_key($expectedItems, $phpClasses));
-
-        $yamlClass = $yamlItems['Epa\\Schema\\AdditionalIdentifier']['Epa\\Schema\\AdditionalIdentifier'];
-        $yamlProperty = $yamlClass['properties']['additionalIdentifierType'];
-
-        /** @var PHPClass $phpClass */
-        $phpClass = $phpClasses['Epa\\Schema\\AdditionalIdentifier'];
-
-        /** @var PHPProperty $phpProperty */
-        $phpProperty = $phpClass->getProperty('additionalIdentifierType');
-
-        /** @var PHPClass $phpType */
-        $phpType = $phpProperty->getType();
-
-        $this->assertSame($yamlProperty['type'], $phpType->getFullName());
+        $this->assertCount(count($yamlItems), $phpClasses);
+        ksort($yamlItems);
+        ksort($phpClasses);
+        $this->assertArraySubset(array_keys($yamlItems), array_keys($phpClasses));
     }
 
     public function testDetectSimpleParents()
     {
-        $expectedItems = array(
-            'Epa\\Schema\\AdditionalIdentifier',
-            'Epa\\Schema\\AdditionalIdentifierType',
-            'Epa\\Schema\\AdditionalIdentifierTypes',
-            'Epa\\Schema\\AdditionalIdentifiers',
-        );
-
-        $expectedItems = array_combine($expectedItems, $expectedItems);
-
         $reader = new SchemaReader();
         $schema = $reader->readFile(__DIR__ . '/data_nested.xsd');
 
@@ -88,32 +134,61 @@ class I40Test extends \PHPUnit_Framework_TestCase
         $yamlConv->addNamespace('', 'Epa\\Schema');
 
         $yamlItems = $yamlConv->convert([$schema]);
-        print_r($yamlItems);
 
-        $phpConv = new PhpConverter(new ShortNamingStrategy());
-        $phpConv->addNamespace('', 'Epa\\Schema');
-
-        $phpClasses = $phpConv->convert([$schema]);
-
-        $pathGenerator = new PhpPsr4PathGenerator(['Epa\\Schema' => __DIR__ . '/'. __FUNCTION__]);
-
-        $classWriter = new PHPClassWriter($pathGenerator);
-        $writer = new PHPWriter($classWriter, new ClassGenerator());
-        $writer->write($phpClasses);
-
+        $this->assertEquals([
+            'Epa\\Schema\\UserType' => [
+                'Epa\\Schema\\UserType' => [
+                    'properties' => [
+                        'additionalIdentifierRootEl' => [
+                            'expose' => true,
+                            'access_type' => 'public_method',
+                            'serialized_name' => 'AdditionalIdentifierRootEl',
+                            'accessor' => [
+                                'getter' => 'getAdditionalIdentifierRootEl',
+                                'setter' => 'setAdditionalIdentifierRootEl',
+                            ],
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'Epa\\Schema\\AdditionalIdentifierRootElType' => [
+                'Epa\\Schema\\AdditionalIdentifierRootElType' => [
+                    'properties' => [
+                        '__value' => [
+                            'expose' => true,
+                            'xml_value' => true,
+                            'access_type' => 'public_method',
+                            'accessor' => [
+                                'getter' => 'value',
+                                'setter' => 'value',
+                            ],
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'Epa\\Schema\\AdditionalIdentifierRootElParentType' => [
+                'Epa\\Schema\\AdditionalIdentifierRootElParentType' => [
+                    'properties' => [
+                        '__value' => [
+                            'expose' => true,
+                            'xml_value' => true,
+                            'access_type' => 'public_method',
+                            'accessor' => [
+                                'getter' => 'value',
+                                'setter' => 'value',
+                            ],
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ], $yamlItems);
     }
 
     public function testDetectSimpleParentsWithAttributes()
     {
-        $expectedItems = array(
-            'Epa\\Schema\\AdditionalIdentifier',
-            'Epa\\Schema\\AdditionalIdentifierType',
-            'Epa\\Schema\\AdditionalIdentifierTypes',
-            'Epa\\Schema\\AdditionalIdentifiers',
-        );
-
-        $expectedItems = array_combine($expectedItems, $expectedItems);
-
         $reader = new SchemaReader();
         $schema = $reader->readFile(__DIR__ . '/data_nested_with_attributes.xsd');
 
@@ -122,31 +197,76 @@ class I40Test extends \PHPUnit_Framework_TestCase
 
         $yamlItems = $yamlConv->convert([$schema]);
 
-        print_r($yamlItems);
+        $this->assertEquals([
+            'Epa\\Schema\\AdditionalIdentifierRootEl' => [
+                'Epa\\Schema\\AdditionalIdentifierRootEl' => [
+                    'xml_root_name' => 'AdditionalIdentifierRootEl',
+                ],
+            ],
+            'Epa\\Schema\\UserType' => [
+                'Epa\\Schema\\UserType' => [
+                    'properties' => [
+                        'additionalIdentifierRootEl' => [
+                            'expose' => true,
+                            'access_type' => 'public_method',
+                            'serialized_name' => 'AdditionalIdentifierRootEl',
+                            'accessor' => [
+                                'getter' => 'getAdditionalIdentifierRootEl',
+                                'setter' => 'setAdditionalIdentifierRootEl',
+                            ],
+                            'type' => 'Epa\\Schema\\AdditionalIdentifierRootElType',
+                        ],
+                    ],
+                ],
+            ],
+            'Epa\\Schema\\AdditionalIdentifierRootElType' => [
+                'Epa\\Schema\\AdditionalIdentifierRootElType' => [
+                    'properties' => [
+                    ],
+                ],
+            ],
+            'Epa\\Schema\\AdditionalIdentifierRootElParentType' => [
+                'Epa\\Schema\\AdditionalIdentifierRootElParentType' => [
+                    'properties' => [
+                        '__value' => [
+                            'expose' => true,
+                            'xml_value' => true,
+                            'access_type' => 'public_method',
+                            'accessor' => [
+                                'getter' => 'value',
+                                'setter' => 'value',
+                            ],
+                            'type' => 'string',
+                        ],
+                        'idType' => [
+                            'expose' => true,
+                            'access_type' => 'public_method',
+                            'serialized_name' => 'idType',
+                            'accessor' => [
+                                'getter' => 'getIdType',
+                                'setter' => 'setIdType',
+                            ],
+                            'xml_attribute' => true,
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ], $yamlItems);
+
         $phpConv = new PhpConverter(new ShortNamingStrategy());
         $phpConv->addNamespace('', 'Epa\\Schema');
 
         $phpClasses = $phpConv->convert([$schema]);
 
-        $pathGenerator = new PhpPsr4PathGenerator(['Epa\\Schema' => __DIR__ . '/'. __FUNCTION__]);
-
-        $classWriter = new PHPClassWriter($pathGenerator);
-        $writer = new PHPWriter($classWriter, new ClassGenerator());
-        $writer->write($phpClasses);
-
+        $this->assertCount(count($yamlItems), $phpClasses);
+        ksort($yamlItems);
+        ksort($phpClasses);
+        $this->assertArraySubset(array_keys($yamlItems), array_keys($phpClasses));
     }
 
     public function testDetectSimpleParentsWithAttributesInTheMiddle()
     {
-        $expectedItems = array(
-            'Epa\\Schema\\AdditionalIdentifier',
-            'Epa\\Schema\\AdditionalIdentifierType',
-            'Epa\\Schema\\AdditionalIdentifierTypes',
-            'Epa\\Schema\\AdditionalIdentifiers',
-        );
-
-        $expectedItems = array_combine($expectedItems, $expectedItems);
-
         $reader = new SchemaReader();
         $schema = $reader->readFile(__DIR__ . '/data_nested_with_attributes_in_the_middle.xsd');
 
@@ -155,18 +275,82 @@ class I40Test extends \PHPUnit_Framework_TestCase
 
         $yamlItems = $yamlConv->convert([$schema]);
 
-        print_r($yamlItems);
+        $this->assertEquals([
+            'Epa\\Schema\\AdditionalIdentifierRootEl' => [
+                'Epa\\Schema\\AdditionalIdentifierRootEl' => [
+                    'xml_root_name' => 'AdditionalIdentifierRootEl',
+                ],
+            ],
+            'Epa\\Schema\\UserType' => [
+                'Epa\\Schema\\UserType' => [
+                    'properties' => [
+                        'additionalIdentifierRootEl' => [
+                            'expose' => true,
+                            'access_type' => 'public_method',
+                            'serialized_name' => 'AdditionalIdentifierRootEl',
+                            'accessor' => [
+                                'getter' => 'getAdditionalIdentifierRootEl',
+                                'setter' => 'setAdditionalIdentifierRootEl',
+                            ],
+                            'type' => 'Epa\\Schema\\AdditionalIdentifierRootElType',
+                        ],
+                    ],
+                ],
+            ],
+            'Epa\\Schema\\AdditionalIdentifierRootElType' => [
+                'Epa\\Schema\\AdditionalIdentifierRootElType' => [
+                    'properties' => [
+                        '__value' => [
+                            'expose' => true,
+                            'xml_value' => true,
+                            'access_type' => 'public_method',
+                            'accessor' => [
+                                'getter' => 'value',
+                                'setter' => 'value',
+                            ],
+                            'type' => 'string',
+                        ],
+                        'idType' => [
+                            'expose' => true,
+                            'access_type' => 'public_method',
+                            'serialized_name' => 'idType',
+                            'accessor' => [
+                                'getter' => 'getIdType',
+                                'setter' => 'setIdType',
+                            ],
+                            'xml_attribute' => true,
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            'Epa\\Schema\\AdditionalIdentifierRootElParentType' => [
+                'Epa\\Schema\\AdditionalIdentifierRootElParentType' => [
+                    'properties' => [
+                        '__value' => [
+                            'expose' => true,
+                            'xml_value' => true,
+                            'access_type' => 'public_method',
+                            'accessor' => [
+                                'getter' => 'value',
+                                'setter' => 'value',
+                            ],
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ], $yamlItems);
 
         $phpConv = new PhpConverter(new ShortNamingStrategy());
         $phpConv->addNamespace('', 'Epa\\Schema');
 
         $phpClasses = $phpConv->convert([$schema]);
 
-        $pathGenerator = new PhpPsr4PathGenerator(['Epa\\Schema' => __DIR__ . '/'. __FUNCTION__]);
+        ksort($yamlItems);
+        ksort($phpClasses);
 
-        $classWriter = new PHPClassWriter($pathGenerator);
-        $writer = new PHPWriter($classWriter, new ClassGenerator());
-        $writer->write($phpClasses);
-
+        $this->assertCount(count($yamlItems), $phpClasses);
+        $this->assertArraySubset(array_keys($yamlItems), array_keys($phpClasses));
     }
 }

--- a/tests/Issues/I40/data_nested.xsd
+++ b/tests/Issues/I40/data_nested.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" version="3.0">
+
+    <xs:complexType name="User">
+        <xs:sequence>
+            <xs:element ref="AdditionalIdentifierRootEl"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="AdditionalIdentifierRootEl" type="AdditionalIdentifierRootElType"/>
+
+    <xs:complexType name="AdditionalIdentifierRootElType">
+        <xs:simpleContent>
+            <xs:extension base="AdditionalIdentifierRootElParent"/>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="AdditionalIdentifierRootElParent">
+        <xs:simpleContent>
+            <xs:extension base="xs:string"/>
+        </xs:simpleContent>
+    </xs:complexType>
+</xs:schema>

--- a/tests/Issues/I40/data_nested_with_attributes.xsd
+++ b/tests/Issues/I40/data_nested_with_attributes.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" version="3.0">
+
+    <xs:complexType name="User">
+        <xs:sequence>
+            <xs:element ref="AdditionalIdentifierRootEl"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="AdditionalIdentifierRootEl" type="AdditionalIdentifierRootElType"/>
+
+    <xs:complexType name="AdditionalIdentifierRootElType">
+        <xs:simpleContent>
+            <xs:extension base="AdditionalIdentifierRootElParent"/>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="AdditionalIdentifierRootElParent">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="idType" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+</xs:schema>

--- a/tests/Issues/I40/data_nested_with_attributes_in_the_middle.xsd
+++ b/tests/Issues/I40/data_nested_with_attributes_in_the_middle.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" version="3.0">
+
+    <xs:complexType name="User">
+        <xs:sequence>
+            <xs:element ref="AdditionalIdentifierRootEl"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="AdditionalIdentifierRootEl" type="AdditionalIdentifierRootElType"/>
+
+    <xs:complexType name="AdditionalIdentifierRootElType">
+        <xs:simpleContent>
+            <xs:extension base="AdditionalIdentifierRootElParent">
+                <xs:attribute name="idType" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="AdditionalIdentifierRootElParent">
+        <xs:simpleContent>
+            <xs:extension base="xs:string"/>
+        </xs:simpleContent>
+    </xs:complexType>
+</xs:schema>

--- a/tests/Issues/I43/I43Test.php
+++ b/tests/Issues/I43/I43Test.php
@@ -1,9 +1,7 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Issues\I40;
 
-use GoetasWebservices\Xsd\XsdToPhp\Jms\YamlConverter;
-use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
-use GoetasWebservices\Xsd\XsdToPhp\Php\PhpConverter;
 use GoetasWebservices\XML\XSDReader\SchemaReader;
 use GoetasWebservices\Xsd\XsdToPhp\Tests\Generator;
 
@@ -14,14 +12,13 @@ class I43Test extends \PHPUnit_Framework_TestCase
      */
     public function testOpcGeneration()
     {
-
-        $nss = array(
-            "http://schemas.openxmlformats.org/package/2006/metadata/core-properties" => "Iag/ECMA376/Package/Model/CoreProperties",
-            "http://purl.org/dc/elements/1.1/" => "Iag/ECMA376/Package/Model/CoreProperties/DcElements",
-            "http://purl.org/dc/terms/" => "Iag/ECMA376/Package/Model/CoreProperties/DcTerms",
-            "http://purl.org/dc/dcmitype/" => "Iag/ECMA376/Package/Model/CoreProperties/DcMiType"
-        );
-        $nss = array_map(function ($a){
+        $nss = [
+            'http://schemas.openxmlformats.org/package/2006/metadata/core-properties' => 'Iag/ECMA376/Package/Model/CoreProperties',
+            'http://purl.org/dc/elements/1.1/' => 'Iag/ECMA376/Package/Model/CoreProperties/DcElements',
+            'http://purl.org/dc/terms/' => 'Iag/ECMA376/Package/Model/CoreProperties/DcTerms',
+            'http://purl.org/dc/dcmitype/' => 'Iag/ECMA376/Package/Model/CoreProperties/DcMiType',
+        ];
+        $nss = array_map(function ($a) {
             return strtr($a, '/', '\\');
         }, $nss);
 
@@ -33,13 +30,13 @@ class I43Test extends \PHPUnit_Framework_TestCase
 
         $schema = $reader->readFile(__DIR__ . '/opc/opc-coreProperties.xsd');
 
-        $generator = new Generator($nss, [],__DIR__ . '/tmp');
+        $generator = new Generator($nss, [], __DIR__ . '/tmp');
 
         list($phpClasses, $yamlItems, $validationItems) = $generator->getData([$schema]);
         $generator->generate([$schema]);
 
-        $this->assertEquals(count($phpClasses), count($yamlItems));
-        $this->assertGreaterThan(0, count($phpClasses));
-        $this->assertGreaterThan(0, count($validationItems));
+        $this->assertGreaterThanOrEqual(24, count($yamlItems));
+        $this->assertGreaterThanOrEqual(24, count($phpClasses));
+        $this->assertGreaterThanOrEqual(3, count($validationItems));
     }
 }

--- a/tests/Issues/I57/I57Test.php
+++ b/tests/Issues/I57/I57Test.php
@@ -1,22 +1,23 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Issues\I57;
 
+use GoetasWebservices\XML\XSDReader\SchemaReader;
 use GoetasWebservices\Xsd\XsdToPhp\Jms\YamlConverter;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
 use GoetasWebservices\Xsd\XsdToPhp\Php\PhpConverter;
-use GoetasWebservices\XML\XSDReader\SchemaReader;
 
 class I57Test extends \PHPUnit_Framework_TestCase
 {
-
     public function testMissingClass()
     {
-
-        $expectedItems = array(
-            'Epa\\Job',
-            'Epa\\Item',
-            'Epa\\Item\\PriceAType'
-        );
+        $expectedItems = [
+            0 => 'Epa\\Job',
+            1 => 'Epa\\Item',
+            2 => 'Epa\\Item\\ItemAType\\PriceAType',
+            3 => 'Epa\\Item\\ItemAType',
+            4 => 'Epa\\Job\\JobAType',
+        ];
 
         $reader = new SchemaReader();
         $schema = $reader->readFile(__DIR__ . '/data.xsd');
@@ -26,6 +27,7 @@ class I57Test extends \PHPUnit_Framework_TestCase
 
         $yamlItems = $yamlConv->convert([$schema]);
         $yamlItems = array_keys($yamlItems);
+
         $this->assertEmpty(array_diff($expectedItems, ($yamlItems)));
 
         $phpConv = new PhpConverter(new ShortNamingStrategy());

--- a/tests/Issues/I63/I63Test.php
+++ b/tests/Issues/I63/I63Test.php
@@ -1,13 +1,13 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Issues\I63;
 
+use GoetasWebservices\XML\XSDReader\SchemaReader;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
 use GoetasWebservices\Xsd\XsdToPhp\Php\PhpConverter;
-use GoetasWebservices\XML\XSDReader\SchemaReader;
 
 class I63Test extends \PHPUnit_Framework_TestCase
 {
-
     public function testNaming()
     {
         $reader = new SchemaReader();

--- a/tests/Issues/I63/I63Test.php
+++ b/tests/Issues/I63/I63Test.php
@@ -17,6 +17,6 @@ class I63Test extends \PHPUnit_Framework_TestCase
         $phpConv->addNamespace('http://www.example.com/', 'Epa');
 
         $phpClasses = $phpConv->convert([$schema]);
-        $this->assertEquals('convertToReseller', $phpClasses['Epa\Two']->getProperty('convertToReseller')->getType()->getArg()->getName());
+        $this->assertEquals('convertToReseller', $phpClasses['Epa\Two\TwoAType']->getProperty('convertToReseller')->getType()->getArg()->getName());
     }
 }

--- a/tests/Issues/I84/I84Test.php
+++ b/tests/Issues/I84/I84Test.php
@@ -1,13 +1,13 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Issues\I63;
 
+use GoetasWebservices\XML\XSDReader\SchemaReader;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
 use GoetasWebservices\Xsd\XsdToPhp\Php\PhpConverter;
-use GoetasWebservices\XML\XSDReader\SchemaReader;
 
 class I84Test extends \PHPUnit_Framework_TestCase
 {
-
     public function testNaming()
     {
         $reader = new SchemaReader();

--- a/tests/JmsSerializer/OTA/OTADateTime.php
+++ b/tests/JmsSerializer/OTA/OTADateTime.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\JmsSerializer\OTA;
 
 class OTADateTime extends \DateTime
 {
-
     const TYPE_DATE = 1;
 
     const TYPE_TIME = 2;

--- a/tests/JmsSerializer/OTA/OTASchemaDateHandler.php
+++ b/tests/JmsSerializer/OTA/OTASchemaDateHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\JmsSerializer\OTA;
 
 use JMS\Serializer\Context;
@@ -10,25 +11,24 @@ use RuntimeException;
 
 class OTASchemaDateHandler implements SubscribingHandlerInterface
 {
-
     protected $defaultTimezone;
 
     public static function getSubscribingMethods()
     {
-        return array(
-            array(
+        return [
+            [
                 'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
                 'format' => 'xml',
                 'type' => 'GoetasWebservices\Xsd\XsdToPhp\Tests\JmsSerializer\OTA\OTADateTime',
-                'method' => 'deserializeDateTime'
-            ),
-            array(
+                'method' => 'deserializeDateTime',
+            ],
+            [
                 'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
                 'format' => 'xml',
                 'type' => 'GoetasWebservices\Xsd\XsdToPhp\Tests\JmsSerializer\OTA\OTADateTime',
-                'method' => 'serializeDateTime'
-            )
-        );
+                'method' => 'serializeDateTime',
+            ],
+        ];
     }
 
     public function __construct($defaultTimezone = 'UTC')
@@ -49,13 +49,14 @@ class OTASchemaDateHandler implements SubscribingHandlerInterface
             $format .= 'H:i:s';
         }
         $v = $date->format($format);
+
         return $visitor->visitSimpleString($v, $type, $context);
     }
 
     public function deserializeDateTime(XmlDeserializationVisitor $visitor, $data, array $type)
     {
         $attributes = $data->attributes('xsi', true);
-        if (isset($attributes['nil'][0]) && (string)$attributes['nil'][0] === 'true') {
+        if (isset($attributes['nil'][0]) && (string) $attributes['nil'][0] === 'true') {
             return null;
         }
 
@@ -83,4 +84,3 @@ class OTASchemaDateHandler implements SubscribingHandlerInterface
         return $datetime;
     }
 }
-

--- a/tests/JmsSerializer/OTA/OTASerializationTest.php
+++ b/tests/JmsSerializer/OTA/OTASerializationTest.php
@@ -4,7 +4,6 @@ namespace GoetasWebservices\Xsd\XsdToPhp\Tests\JmsSerializer\OTA;
 
 use Doctrine\Common\Inflector\Inflector;
 use GoetasWebservices\XML\XSDReader\SchemaReader;
-use GoetasWebservices\Xsd\XsdToPhp\Jms\Handler\OTA\SchemaDateHandler;
 use GoetasWebservices\Xsd\XsdToPhp\Tests\Generator;
 use GoetasWebservices\Xsd\XsdToPhpRuntime\Jms\Handler\BaseTypesHandler;
 use GoetasWebservices\Xsd\XsdToPhpRuntime\Jms\Handler\XmlSchemaDateHandler;
@@ -34,15 +33,15 @@ class OTASerializationTest extends \PHPUnit_Framework_TestCase
         }
 
         self::$generator = new Generator([
-            'http://www.opentravel.org/OTA/2003/05' => self::$namespace
+            'http://www.opentravel.org/OTA/2003/05' => self::$namespace,
         ], [
             ['http://www.opentravel.org/OTA/2003/05', 'DateOrTimeOrDateTimeType', 'GoetasWebservices\Xsd\XsdToPhp\Tests\JmsSerializer\OTA\OTADateTime'],
             ['http://www.opentravel.org/OTA/2003/05', 'DateOrDateTimeType', 'GoetasWebservices\Xsd\XsdToPhp\Tests\JmsSerializer\OTA\OTADateTime'],
-            ['http://www.opentravel.org/OTA/2003/05', 'TimeOrDateTimeType', 'GoetasWebservices\Xsd\XsdToPhp\Tests\JmsSerializer\OTA\OTADateTime']
+            ['http://www.opentravel.org/OTA/2003/05', 'TimeOrDateTimeType', 'GoetasWebservices\Xsd\XsdToPhp\Tests\JmsSerializer\OTA\OTADateTime'],
         ]);
 
         $reader = new SchemaReader();
-        $schemas = array();
+        $schemas = [];
         foreach (self::$files as $d) {
             if (!isset($schemas[$d[1]])) {
                 $schemas[$d[1]] = $reader->readFile($d[1]);
@@ -62,35 +61,35 @@ class OTASerializationTest extends \PHPUnit_Framework_TestCase
     protected function clearXML($xml)
     {
         $xml = str_replace("\r", "\n", $xml);
-        $xml = str_replace(array(
-            'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
-        ), '', $xml);
+        $xml = str_replace([
+            'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"',
+        ], '', $xml);
         $xml = preg_replace('~xsi:[a-z]+="[^"]+"~msi', '', $xml);
 
-        $xml = preg_replace("/" . preg_quote('<![CDATA[', '/') . "(.*?)" . preg_quote(']]>', '/') . "/mis", "\\1", $xml);
+        $xml = preg_replace('/' . preg_quote('<![CDATA[', '/') . '(.*?)' . preg_quote(']]>', '/') . '/mis', '\\1', $xml);
 
         $xml = str_replace('&', '', $xml);
-        $xml = preg_replace_callback('/(ItinSeqNumber|UnitOfMeasureQuantity|Quantity)="(\d+)"/', function ($mch){
-            return $mch[1].'="'.intval($mch[2]).'"';
+        $xml = preg_replace_callback('/(ItinSeqNumber|UnitOfMeasureQuantity|Quantity)="(\d+)"/', function ($mch) {
+            return $mch[1] . '="' . intval($mch[2]) . '"';
         }, $xml);
 
         $dom = new \DOMDocument();
         if (!$dom->loadXML($xml)) {
-            file_put_contents("d.xml", $xml);
+            file_put_contents('d.xml', $xml);
         }
 
         $fix = function ($str) {
             $str = trim($str);
             // period
-            if (preg_match("/^P([0-9]+[A-Z])+/", $str) || preg_match("/^PT([0-9]+[A-Z])+$/", $str)) {
-                $str = str_replace("N", "D", $str);
-                while (preg_match("/P0+[A-Z]/", $str)) {
-                    $str = preg_replace("/P0+[A-Z]/", "P", $str); //P0D => P
+            if (preg_match('/^P([0-9]+[A-Z])+/', $str) || preg_match('/^PT([0-9]+[A-Z])+$/', $str)) {
+                $str = str_replace('N', 'D', $str);
+                while (preg_match('/P0+[A-Z]/', $str)) {
+                    $str = preg_replace('/P0+[A-Z]/', 'P', $str); //P0D => P
                 }
-                while (preg_match("/T0+[A-Z]/", $str)) {
-                    $str = preg_replace("/T0+[A-Z]/", "T", $str); //T0H => T
+                while (preg_match('/T0+[A-Z]/', $str)) {
+                    $str = preg_replace('/T0+[A-Z]/', 'T', $str); //T0H => T
                 }
-                if ($str[strlen($str) - 1] == "T") {
+                if ($str[strlen($str) - 1] == 'T') {
                     $str = substr($str, 0, -1);
                 }
             }
@@ -99,10 +98,10 @@ class OTASerializationTest extends \PHPUnit_Framework_TestCase
             $str = str_replace(['true', 'false'], ['1', '0'], $str); // 'true' => '1'
 
             // datetime
-            $str = str_replace(array(
+            $str = str_replace([
                 '+00:00',
-                '-05:00'
-            ), '', $str);
+                '-05:00',
+            ], '', $str);
 
             $str = preg_replace('/Z$/', '', $str);
 
@@ -112,6 +111,7 @@ class OTASerializationTest extends \PHPUnit_Framework_TestCase
             } else {
                 $str = preg_replace('/\.0+$/', '', $str); // 1.0000 => 1, .0 => ''
             }
+
             return $str;
         };
 
@@ -124,10 +124,10 @@ class OTASerializationTest extends \PHPUnit_Framework_TestCase
             }
         } while ($l);
 
-        foreach ($xp->query("//@*") as $attr) {
+        foreach ($xp->query('//@*') as $attr) {
             $attr->value = $fix($attr->value);
         }
-        foreach ($xp->query("//text()") as $text) {
+        foreach ($xp->query('//text()') as $text) {
             $text->data = $fix($text->data);
         }
 
@@ -143,7 +143,6 @@ class OTASerializationTest extends \PHPUnit_Framework_TestCase
      */
     public function testConversion($xml, $xsd, $class)
     {
-
         $serializer = self::$generator->buildSerializer(function (HandlerRegistryInterface $h) {
             $h->registerSubscribingHandler(new XmlSchemaDateHandler());
             $h->registerSubscribingHandler(new OTASchemaDateHandler());
@@ -162,9 +161,9 @@ class OTASerializationTest extends \PHPUnit_Framework_TestCase
         $notEqual = strpos($diff, '<dm:copy count="1"/>') === false || strlen($diff) > 110;
 
         if (0 && $notEqual) {
-            file_put_contents("a.xml", $original);
-            file_put_contents("b.xml", $new);
-            file_put_contents("c.xml", $diff);
+            file_put_contents('a.xml', $original);
+            file_put_contents('b.xml', $new);
+            file_put_contents('c.xml', $diff);
             exit;
         }
 
@@ -177,7 +176,7 @@ class OTASerializationTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidation($xml, $xsd, $class)
     {
-        if (strpos($xml, 'OTA_UpdateRQ.xml')!==false) {
+        if (strpos($xml, 'OTA_UpdateRQ.xml') !== false) {
             if (!class_exists(Versions::class) || version_compare(Versions::getVersion('goetas-webservices/xsd-reader'), '0.3.6', '<')) {
                 $this->markTestSkipped();
             }
@@ -196,33 +195,35 @@ class OTASerializationTest extends \PHPUnit_Framework_TestCase
 
         $xmlDom = new \DOMDocument();
 
-        if (!@$xmlDom->load($xml)){
+        if (!@$xmlDom->load($xml)) {
             $this->markTestSkipped();
+
             return;
         }
 
         if (@$xmlDom->schemaValidate($xsd)) {
-            $this->assertCount(0, $violations, 'Validation errors in '.$xml);
+            $this->assertCount(0, $violations, 'Validation errors in ' . $xml);
         }
     }
 
     private static function getXmlFiles()
     {
-        $files = glob(__DIR__ . "/otaxml/*.xml");
+        $files = glob(__DIR__ . '/otaxml/*.xml');
 
-        $tests = array();
+        $tests = [];
         foreach ($files as $n => $file) {
             $name = basename($file);
             $dir = dirname($file);
 
-            $name = str_replace(".xml", ".xsd", $name);
-            $name = preg_replace("/[0-9]+/", "", $name);
-            if (is_file($dir . "/" . $name)) {
+            $name = str_replace('.xml', '.xsd', $name);
+            $name = preg_replace('/[0-9]+/', '', $name);
+            if (is_file($dir . '/' . $name)) {
                 $tests[$n][0] = $file;
-                $tests[$n][1] = $dir . "/" . $name;
-                $tests[$n][2] = self::$namespace . "\\" . Inflector::classify(str_replace(".xsd", "", $name));
+                $tests[$n][1] = $dir . '/' . $name;
+                $tests[$n][2] = self::$namespace . '\\' . Inflector::classify(str_replace('.xsd', '', $name));
             }
         }
+
         return $tests;
     }
 
@@ -231,6 +232,7 @@ class OTASerializationTest extends \PHPUnit_Framework_TestCase
         if (!self::$files) {
             self::$files = self::getXmlFiles();
         }
+
         return self::$files;
     }
 }

--- a/tests/PHP/AnyTypePHPConversionTest.php
+++ b/tests/PHP/AnyTypePHPConversionTest.php
@@ -1,21 +1,21 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\JmsSerializer\OTA;
 
+use GoetasWebservices\XML\XSDReader\SchemaReader;
 use GoetasWebservices\Xsd\XsdToPhp\Jms\YamlConverter;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
 use GoetasWebservices\Xsd\XsdToPhp\Php\ClassGenerator;
 use GoetasWebservices\Xsd\XsdToPhp\Php\PhpConverter;
-use GoetasWebservices\XML\XSDReader\SchemaReader;
 
 class AnyTypePHPConversionTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
-     *
      * @param mixed $xml
+     *
      * @return array[]
      */
-    protected function getYamlFiles($xml, array $types = array())
+    protected function getYamlFiles($xml, array $types = [])
     {
         $creator = new YamlConverter(new ShortNamingStrategy());
         $creator->addNamespace('', 'Example');
@@ -29,7 +29,7 @@ class AnyTypePHPConversionTest extends \PHPUnit_Framework_TestCase
 
         if (!is_array($xml)) {
             $xml = [
-                'schema.xsd' => $xml
+                'schema.xsd' => $xml,
             ];
         }
         $schemas = [];
@@ -42,11 +42,11 @@ class AnyTypePHPConversionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     *
      * @param mixed $xml
+     *
      * @return \Laminas\Code\Generator\ClassGenerator[]
      */
-    protected function getPhpClasses($xml, array $types = array())
+    protected function getPhpClasses($xml, array $types = [])
     {
         $creator = new PhpConverter(new ShortNamingStrategy());
         $creator->addNamespace('', 'Example');
@@ -61,7 +61,7 @@ class AnyTypePHPConversionTest extends \PHPUnit_Framework_TestCase
 
         if (!is_array($xml)) {
             $xml = [
-                'schema.xsd' => $xml
+                'schema.xsd' => $xml,
             ];
         }
         $schemas = [];
@@ -70,12 +70,13 @@ class AnyTypePHPConversionTest extends \PHPUnit_Framework_TestCase
         }
         $items = $creator->convert($schemas);
 
-        $classes = array();
+        $classes = [];
         foreach ($items as $k => $item) {
             if ($codegen = $generator->generate($item)) {
                 $classes[$k] = $codegen;
             }
         }
+
         return $classes;
     }
 
@@ -90,10 +91,9 @@ class AnyTypePHPConversionTest extends \PHPUnit_Framework_TestCase
                 </xs:complexType>
             </xs:schema>';
 
-        $items = $this->getPhpClasses($xml, array(
-            ['http://www.w3.org/2001/XMLSchema', 'anyType', 'mixed']
-        ));
-
+        $items = $this->getPhpClasses($xml, [
+            ['http://www.w3.org/2001/XMLSchema', 'anyType', 'mixed'],
+        ]);
 
         $this->assertCount(1, $items);
 
@@ -119,30 +119,29 @@ class AnyTypePHPConversionTest extends \PHPUnit_Framework_TestCase
                 </xs:complexType>
             </xs:schema>';
 
-        $items = $this->getYamlFiles($xml, array(
-            ['http://www.w3.org/2001/XMLSchema', 'anyType', 'My\Custom\MixedTypeHandler']
-        ));
-
+        $items = $this->getYamlFiles($xml, [
+            ['http://www.w3.org/2001/XMLSchema', 'anyType', 'My\Custom\MixedTypeHandler'],
+        ]);
 
         $this->assertCount(1, $items);
 
         $single = $items['Example\SingleType'];
 
-        $this->assertEquals(array(
-            'Example\\SingleType' => array(
-                'properties' => array(
-                    'id' => array(
+        $this->assertEquals([
+            'Example\\SingleType' => [
+                'properties' => [
+                    'id' => [
                         'expose' => true,
                         'access_type' => 'public_method',
                         'serialized_name' => 'id',
-                        'accessor' => array(
+                        'accessor' => [
                             'getter' => 'getId',
-                            'setter' => 'setId'
-                        ),
-                        'type' => 'My\\Custom\\MixedTypeHandler'
-                    )
-                )
-            )
-        ), $single);
+                            'setter' => 'setId',
+                        ],
+                        'type' => 'My\\Custom\\MixedTypeHandler',
+                    ],
+                ],
+            ],
+        ], $single);
     }
 }

--- a/tests/PHP/PHPConversionTest.php
+++ b/tests/PHP/PHPConversionTest.php
@@ -1,17 +1,17 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\JmsSerializer\OTA;
 
+use GoetasWebservices\XML\XSDReader\SchemaReader;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
 use GoetasWebservices\Xsd\XsdToPhp\Php\ClassGenerator;
 use GoetasWebservices\Xsd\XsdToPhp\Php\PhpConverter;
-use GoetasWebservices\XML\XSDReader\SchemaReader;
 
 class PHPConversionTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
-     *
      * @param mixed $xml
+     *
      * @return \Laminas\Code\Generator\ClassGenerator[]
      */
     protected function getClasses($xml)
@@ -24,7 +24,7 @@ class PHPConversionTest extends \PHPUnit_Framework_TestCase
 
         if (!is_array($xml)) {
             $xml = [
-                'schema.xsd' => $xml
+                'schema.xsd' => $xml,
             ];
         }
         $schemas = [];
@@ -33,12 +33,13 @@ class PHPConversionTest extends \PHPUnit_Framework_TestCase
         }
         $items = $phpcreator->convert($schemas);
 
-        $classes = array();
+        $classes = [];
         foreach ($items as $k => $item) {
             if ($codegen = $generator->generate($item)) {
                 $classes[$k] = $codegen;
             }
         }
+
         return $classes;
     }
 
@@ -94,7 +95,6 @@ class PHPConversionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($codegen->hasMethod('__toString'));
     }
 
-
     public function testNoMulteplicity()
     {
         $xml = '
@@ -148,7 +148,6 @@ class PHPConversionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($codegen->getMethod('issetId')->getParameters()['index']->getType());
         $this->assertNull($codegen->getMethod('issetId')->getParameters()['index']->getType());
-
     }
 
     public function testNestedMulteplicity()
@@ -219,7 +218,6 @@ class PHPConversionTest extends \PHPUnit_Framework_TestCase
         $single = $items['Example\SingleType'];
         $this->assertTrue($single->hasMethod('addToA'));
         $this->assertTrue($single->hasMethod('addToB'));
-
     }
 
     public function testSimpleMulteplicity()

--- a/tests/PathGenerator/JMSPathGeneratorTest.php
+++ b/tests/PathGenerator/JMSPathGeneratorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Php\PathGenerator;
 
 use GoetasWebservices\Xsd\XsdToPhp\Jms\PathGenerator\Psr4PathGenerator;
@@ -11,8 +12,8 @@ class JMSPathGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $tmp = sys_get_temp_dir();
 
-        if (is_writable("/dev/shm")) {
-            $tmp = "/dev/shm";
+        if (is_writable('/dev/shm')) {
+            $tmp = '/dev/shm';
         }
 
         $this->tmpdir = "$tmp/PathGeneratorTest";
@@ -24,30 +25,30 @@ class JMSPathGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testNoNs()
     {
         $this->setExpectedException('GoetasWebservices\Xsd\XsdToPhp\PathGenerator\PathGeneratorException');
-        $generator = new Psr4PathGenerator(array(
-            'myns2\\' => $this->tmpdir
-        ));
-        $generator->getPath(array('myns\Bar' => true));
+        $generator = new Psr4PathGenerator([
+            'myns2\\' => $this->tmpdir,
+        ]);
+        $generator->getPath(['myns\Bar' => true]);
     }
 
     public function testWriterLong()
     {
-        $generator = new Psr4PathGenerator(array(
-            'myns\\' => $this->tmpdir
-        ));
+        $generator = new Psr4PathGenerator([
+            'myns\\' => $this->tmpdir,
+        ]);
 
-        $path = $generator->getPath(array('myns\foo\Bar' => true));
-        $this->assertEquals($path, $this->tmpdir . "/foo.Bar.yml");
+        $path = $generator->getPath(['myns\foo\Bar' => true]);
+        $this->assertEquals($path, $this->tmpdir . '/foo.Bar.yml');
     }
 
     public function testWriter()
     {
-        $generator = new Psr4PathGenerator(array(
-            'myns\\' => $this->tmpdir
-        ));
+        $generator = new Psr4PathGenerator([
+            'myns\\' => $this->tmpdir,
+        ]);
 
-        $path = $generator->getPath(array('myns\Bar' => true));
+        $path = $generator->getPath(['myns\Bar' => true]);
 
-        $this->assertEquals($path, $this->tmpdir . "/Bar.yml");
+        $this->assertEquals($path, $this->tmpdir . '/Bar.yml');
     }
 }

--- a/tests/PathGenerator/PHPPathGeneratorTest.php
+++ b/tests/PathGenerator/PHPPathGeneratorTest.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Php\PathGenerator;
 
 use GoetasWebservices\Xsd\XsdToPhp\Php\PathGenerator\Psr4PathGenerator;
-use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass;
 use Laminas\Code\Generator\ClassGenerator;
 
 class PHPPathGeneratorTest extends \PHPUnit_Framework_TestCase
@@ -13,8 +13,8 @@ class PHPPathGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $tmp = sys_get_temp_dir();
 
-        if (is_writable("/dev/shm")) {
-            $tmp = "/dev/shm";
+        if (is_writable('/dev/shm')) {
+            $tmp = '/dev/shm';
         }
 
         $this->tmpdir = "$tmp/PathGeneratorTest";
@@ -26,33 +26,33 @@ class PHPPathGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testNoNs()
     {
         $this->setExpectedException('GoetasWebservices\Xsd\XsdToPhp\PathGenerator\PathGeneratorException');
-        $generator = new Psr4PathGenerator(array(
-            'myns\\' => $this->tmpdir
-        ));
+        $generator = new Psr4PathGenerator([
+            'myns\\' => $this->tmpdir,
+        ]);
         $class = new ClassGenerator('Bar', 'myns2');
         $generator->getPath($class);
     }
 
     public function testWriterLong()
     {
-        $generator = new Psr4PathGenerator(array(
-            'myns\\' => $this->tmpdir
-        ));
+        $generator = new Psr4PathGenerator([
+            'myns\\' => $this->tmpdir,
+        ]);
 
         $class = new ClassGenerator('Bar', 'myns\foo');
         $path = $generator->getPath($class);
 
-        $this->assertEquals($path, $this->tmpdir . "/foo/Bar.php");
+        $this->assertEquals($path, $this->tmpdir . '/foo/Bar.php');
     }
 
     public function testWriter()
     {
-        $generator = new Psr4PathGenerator(array(
-            'myns\\' => $this->tmpdir
-        ));
+        $generator = new Psr4PathGenerator([
+            'myns\\' => $this->tmpdir,
+        ]);
         $class = new ClassGenerator('Bar', 'myns');
         $path = $generator->getPath($class);
 
-        $this->assertEquals($path, $this->tmpdir . "/Bar.php");
+        $this->assertEquals($path, $this->tmpdir . '/Bar.php');
     }
 }

--- a/tests/Validator/ValidatorTest.php
+++ b/tests/Validator/ValidatorTest.php
@@ -1,11 +1,11 @@
 <?php
+
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\Php\PathGenerator;
 
 use Composer\Autoload\ClassLoader;
+use ota\TestNotNullType;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
-
-use ota\TestNotNullType;
 
 class ValidatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -17,12 +17,12 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $loader = new ClassLoader();
-        $loader->addPsr4("ota\\", __DIR__."/ota/php");
+        $loader->addPsr4('ota\\', __DIR__ . '/ota/php');
         $loader->register();
 
         $builder = Validation::createValidatorBuilder();
 
-        foreach (glob(__DIR__.'/ota/validator/*.yml') as $file) {
+        foreach (glob(__DIR__ . '/ota/validator/*.yml') as $file) {
             $builder->addYamlMapping($file);
         }
 
@@ -31,16 +31,14 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testNotNullViolations()
     {
-        
         $object = new TestNotNullType();
         $violations = $this->validator->validate($object);
-        
+
         $this->assertEquals(1, count($violations));
-        
+
         $object->setValue('My value');
         $violations = $this->validator->validate($object);
-        
+
         $this->assertEquals(0, count($violations));
-        
     }
 }

--- a/tests/Validator/ota/php/TestNotNullType.php
+++ b/tests/Validator/ota/php/TestNotNullType.php
@@ -3,14 +3,12 @@
 namespace ota;
 
 /**
- * Class representing TestNotNull
+ * Class representing TestNotNull.
  *
- * 
  * XSD Type: testNotNull
  */
 class TestNotNullType
 {
-
     /**
      * @property string
      * $value
@@ -18,7 +16,7 @@ class TestNotNullType
     private $value = null;
 
     /**
-     * Gets as value
+     * Gets as value.
      *
      * @return string
      */
@@ -28,16 +26,16 @@ class TestNotNullType
     }
 
     /**
-     * Sets a new value
+     * Sets a new value.
      *
      * @param string $value
+     *
      * @return self
      */
     public function setValue($value)
     {
         $this->value = $value;
+
         return $this;
     }
-
 }
-

--- a/tests/VeryShortNamingStrategy.php
+++ b/tests/VeryShortNamingStrategy.php
@@ -7,13 +7,13 @@ use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
 
 /**
- * The OTA psr4 class paths can exceed windows max dir length
+ * The OTA psr4 class paths can exceed windows max dir length.
  */
 class VeryShortNamingStrategy extends ShortNamingStrategy
 {
     /**
-     * Suffix with 'T' instead of 'Type'
-     * @param Type $type
+     * Suffix with 'T' instead of 'Type'.
+     *
      * @return string
      */
     public function getTypeName(Type $type)
@@ -32,9 +32,10 @@ class VeryShortNamingStrategy extends ShortNamingStrategy
     }
 
     /**
-     * Suffix with 'A' instead of 'AType'
-     * @param Type $type
+     * Suffix with 'A' instead of 'AType'.
+     *
      * @param string $parentName
+     *
      * @return string
      */
     public function getAnonymousTypeName(Type $type, $parentName)
@@ -44,10 +45,11 @@ class VeryShortNamingStrategy extends ShortNamingStrategy
 
     /**
      * @param string $name
+     *
      * @return string
      */
     private function classify($name)
     {
-        return Inflector::classify(str_replace(".", " ", $name));
+        return Inflector::classify(str_replace('.', ' ', $name));
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,2 +1,3 @@
 <?php
-require __DIR__. '/../vendor/autoload.php';
+
+require __DIR__ . '/../vendor/autoload.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,5 @@
 <?php
 
 require __DIR__ . '/../vendor/autoload.php';
+
+ini_set('memory_limit', -1);


### PR DESCRIPTION
This changes internally quite a lot of things.

The main changes are:
-  Root elements have always a parent type
- when a type can be simplified to a PHP type, it gets simplified (extensions or restrictions on base types)