### PR TITLE
Fix setter of nillable element value

### DIFF
--- a/src/Php/ClassGenerator.php
+++ b/src/Php/ClassGenerator.php
@@ -147,9 +147,6 @@ class ClassGenerator
                 if (($t = $p->getType()) && !$t->isNativeType()) {
                     $patramTag->setTypes($t->getPhpType());
                     $parameter->setType($t->getPhpType());
-                } elseif ($t && !$t->isNativeType()) {
-                    $patramTag->setTypes($t->getPhpType());
-                    $parameter->setType($t->getPhpType());
                 } elseif ($t) {
                     $patramTag->setTypes($t->getPhpType());
                 }
@@ -157,6 +154,10 @@ class ClassGenerator
                 $patramTag->setTypes($type->getPhpType());
                 $parameter->setType($type->getPhpType());
             }
+        }
+
+        if ($prop->getNullable() && $parameter->getType()) {
+            $parameter->setDefaultValue(null);
         }
 
         $methodBody .= '$this->' . $prop->getName() . ' = $' . $prop->getName() . ';' . PHP_EOL;

--- a/src/Php/PhpConverter.php
+++ b/src/Php/PhpConverter.php
@@ -174,8 +174,7 @@ class PhpConverter extends AbstractConverter
 
             $skip = in_array($element->getSchema()->getTargetNamespace(), $this->baseSchemas, true)
                 || $this->getTypeAlias($type, $type->getSchema())
-                || $typeClass->getPropertyInHierarchy('__value')
-            ;
+                || $typeClass->getPropertyInHierarchy('__value');
             $this->classes[spl_object_hash($element)]['class'] = $class;
             $this->classes[spl_object_hash($element)]['skip'] = $skip;
             $this->skipByType[spl_object_hash($class)] = $skip;
@@ -266,7 +265,7 @@ class PhpConverter extends AbstractConverter
                 return $class;
             }
 
-            $this->classes[spl_object_hash($type)]['skip'] = $skip || (bool) $this->getTypeAlias($type);
+            $this->classes[spl_object_hash($type)]['skip'] = $skip || (bool)$this->getTypeAlias($type);
         } elseif ($force) {
             if (!($type instanceof SimpleType) && !$this->getTypeAlias($type)) {
                 $this->classes[spl_object_hash($type)]['skip'] = in_array($type->getSchema()->getTargetNamespace(), $this->baseSchemas, true);
@@ -404,7 +403,7 @@ class PhpConverter extends AbstractConverter
 
     /**
      * @param Element $element
-     * @param bool    $arrayize
+     * @param bool $arrayize
      *
      * @return \GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPProperty
      */
@@ -413,6 +412,9 @@ class PhpConverter extends AbstractConverter
         $property = new PHPProperty();
         $property->setName($this->getNamingStrategy()->getPropertyName($element));
         $property->setDoc($element->getDoc());
+        if ($element->isNil()) {
+            $property->setNullable(true);
+        }
 
         $t = $element->getType();
 

--- a/src/Php/Structure/PHPArg.php
+++ b/src/Php/Structure/PHPArg.php
@@ -10,6 +10,8 @@ class PHPArg
 
     protected $name;
 
+    protected $nullable = false;
+    
     protected $default;
 
     public function __construct($name = null, $type = null)
@@ -57,6 +59,18 @@ class PHPArg
         return $this;
     }
 
+    public function getNullable()
+    {
+        return $this->nullable;
+    }
+
+    public function setNullable($nullable)
+    {
+        $this->nullable = $nullable;
+        
+        return $this;
+    }
+    
     public function getDefault()
     {
         return $this->default;

--- a/tests/PHP/PHPConversionTest.php
+++ b/tests/PHP/PHPConversionTest.php
@@ -253,4 +253,32 @@ class PHPConversionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($single->hasMethod('getId'));
         $this->assertTrue($single->hasMethod('setId'));
     }
+
+    public function testNillableElement()
+    {
+        $xml = '
+            <xs:schema targetNamespace="http://www.example.com"
+            xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                <xs:complexType name="single">
+                    <xs:all>
+                        <xs:element name="date1" type="xs:date" nillable="true"/>
+                        <xs:element name="date2" type="xs:date"/>
+                        <xs:element name="str1" type="xs:string" nillable="true"/>
+                        <xs:element name="str2" type="xs:string"/>
+                    </xs:all>
+                </xs:complexType>
+            </xs:schema>';
+
+        $items = $this->getClasses($xml);
+        $codegen = $items['Example\SingleType'];
+
+        $this->assertTrue($codegen->hasMethod('setDate1'));
+        $this->assertNull($codegen->getMethod('setDate1')->getParameters()['date1']->getDefaultValue()->getValue());
+        $this->assertTrue($codegen->hasMethod('setDate2'));
+        $this->assertNull($codegen->getMethod('setDate2')->getParameters()['date2']->getDefaultValue());
+        $this->assertTrue($codegen->hasMethod('setStr1'));
+        $this->assertNull($codegen->getMethod('setStr1')->getParameters()['str1']->getDefaultValue());
+        $this->assertTrue($codegen->hasMethod('setStr2'));
+        $this->assertNull($codegen->getMethod('setStr2')->getParameters()['str2']->getDefaultValue());
+    }
 }


### PR DESCRIPTION
Generated setters do not allow to set value to null.
For example:
for xsd
<xs:element name="my_date" type="xs:date" nillable="true"/>
it generates
function setMyDate(\DateTime $myDate)
but should be
function setMyDate(\DateTime $myDate = null)