### PR TITLE
Add nullable strict types for native and simple arguments

### DIFF
--- a/src/Php/ClassGenerator.php
+++ b/src/Php/ClassGenerator.php
@@ -144,12 +144,15 @@ class ClassGenerator
         } elseif ($type) {
             if ($type->isNativeType()) {
                 $patramTag->setTypes($type->getPhpType());
+                $parameter->setType($type->getPhpType()); // Added by rvdb
             } elseif ($p = $type->isSimpleType()) {
                 if (($t = $p->getType()) && !$t->isNativeType()) {
                     $patramTag->setTypes($t->getPhpType());
                     $parameter->setType($t->getPhpType());
                 } elseif ($t) {
                     $patramTag->setTypes($t->getPhpType());
+                    $parameter->setType($t->getPhpType()); // Added by rvdb
+
                 }
             } else {
                 $patramTag->setTypes($type->getPhpType());

--- a/src/Php/ClassGenerator.php
+++ b/src/Php/ClassGenerator.php
@@ -17,6 +17,13 @@ use Laminas\Code\Generator\PropertyGenerator;
 
 class ClassGenerator
 {
+    private $strictTypes;
+
+    public function __construct(bool $strictTypes = false)
+    {
+        $this->strictTypes = $strictTypes;
+    }
+
     private function handleBody(Generator\ClassGenerator $class, PHPClass $type)
     {
         foreach ($type->getProperties() as $prop) {
@@ -144,15 +151,18 @@ class ClassGenerator
         } elseif ($type) {
             if ($type->isNativeType()) {
                 $patramTag->setTypes($type->getPhpType());
-                $parameter->setType($type->getPhpType()); // Added by rvdb: add strict typing for scalar arguments
+                if ($this->strictTypes) {
+                    $parameter->setType($type->getPhpType());
+                }
             } elseif ($p = $type->isSimpleType()) {
                 if (($t = $p->getType()) && !$t->isNativeType()) {
                     $patramTag->setTypes($t->getPhpType());
                     $parameter->setType($t->getPhpType());
                 } elseif ($t) {
                     $patramTag->setTypes($t->getPhpType());
-                    $parameter->setType($t->getPhpType()); // Added by rvdb: add strict typing for simple arguments
-
+                    if ($this->strictTypes) {
+                        $parameter->setType($t->getPhpType());
+                    }
                 }
             } else {
                 $patramTag->setTypes($type->getPhpType());
@@ -160,7 +170,7 @@ class ClassGenerator
             }
         }
 
-        if ($prop->getDefault() === null) {      // Added by rvdb: make setter arguments nullable
+        if ($this->strictTypes && $prop->getDefault() === null) {
             $parameter->setDefaultValue(null);
         }
 

--- a/src/Php/ClassGenerator.php
+++ b/src/Php/ClassGenerator.php
@@ -144,20 +144,24 @@ class ClassGenerator
         } elseif ($type) {
             if ($type->isNativeType()) {
                 $patramTag->setTypes($type->getPhpType());
-                $parameter->setType($type->getPhpType()); // Added by rvdb
+                $parameter->setType($type->getPhpType()); // Added by rvdb: add strict typing for scalar arguments
             } elseif ($p = $type->isSimpleType()) {
                 if (($t = $p->getType()) && !$t->isNativeType()) {
                     $patramTag->setTypes($t->getPhpType());
                     $parameter->setType($t->getPhpType());
                 } elseif ($t) {
                     $patramTag->setTypes($t->getPhpType());
-                    $parameter->setType($t->getPhpType()); // Added by rvdb
+                    $parameter->setType($t->getPhpType()); // Added by rvdb: add strict typing for simple arguments
 
                 }
             } else {
                 $patramTag->setTypes($type->getPhpType());
                 $parameter->setType(($prop->getNullable() ? '?' : '') . $type->getPhpType());
             }
+        }
+
+        if ($prop->getDefault() === null) {      // Added by rvdb: make setter arguments nullable
+            $parameter->setDefaultValue(null);
         }
 
         if ($prop->getNullable() && $parameter->getType()) {

--- a/tests/AbstractGenerator.php
+++ b/tests/AbstractGenerator.php
@@ -19,6 +19,7 @@ abstract class AbstractGenerator
 {
     protected $targetNs = [];
     protected $aliases = [];
+    protected $strictTypes;
 
     protected $phpDir;
     protected $jmsDir;
@@ -28,12 +29,14 @@ abstract class AbstractGenerator
 
     private $loader;
 
-    public function __construct(array $targetNs, array $aliases = [], $tmp = null)
+
+    public function __construct(array $targetNs, array $aliases = [], $tmp = null, bool $strictTypes = false)
     {
         $tmp = $tmp ?: sys_get_temp_dir();
 
         $this->targetNs = $targetNs;
         $this->aliases = $aliases;
+        $this->strictTypes = $strictTypes;
 
         $this->phpDir = "$tmp/php";
         $this->jmsDir = "$tmp/jms";
@@ -146,7 +149,7 @@ abstract class AbstractGenerator
         $pathGenerator = new PhpPsr4PathGenerator($paths);
 
         $classWriter = new PHPClassWriter($pathGenerator);
-        $writer = new PHPWriter($classWriter, new ClassGenerator());
+        $writer = new PHPWriter($classWriter, new ClassGenerator($this->strictTypes));
         $writer->write($items);
     }
 


### PR DESCRIPTION
Just wanted to discuss this with you.. I have had a fork of this repo for a long time, with below addition. It forces strict types for scalar and simple arguments, which is way cleaner for my static analyser etc. I did, however, add a nullable default type for all values, as I don't know exactly how to determine if a value should be nullable or not.

What do you think about this? Have you tried to add strict types before or do you still want to be BC with php < 7?