### PR TITLE
Update PHP Dependency to >=7.1 to support PHP 8 and later

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "require": {
-    "php": "^7.1",
+    "php": ">=7.1",
     "symfony/console": "^2.7|^3.0|^4.0|^5.0",
     "symfony/dependency-injection": "^2.2|^3.0|^4.0|^5.0",
     "symfony/yaml": "^2.2|^3.0|^4.0|^5.0",


### PR DESCRIPTION
To get rid of the annoying message from `composer install`

Checked with PHP 8.0.1 

```
Testing started at 15:36 ...
Xdebug: [Log Files] File '/tmp/xdebug.log' could not be opened.
PHP Warning:  Private methods cannot be final as they are never overridden by other classes in /home/swe5/xsd2php/vendor/phpunit/phpunit/src/Util/Configuration.php on line 162
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.


Test ignored.

 /home/swe5/xsd2php/tests/JmsSerializer/OTA/OTASerializationTest.php:181
 


Time: 43.05 seconds, Memory: 138.50MB

OK, but incomplete, skipped, or risky tests!
Tests: 789, Assertions: 995, Skipped: 1.

Process finished with exit code 0
```