### PR TITLE
Updating inflector to use 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "symfony/yaml": "^2.2|^3.0|^4.0|^5.0",
     "symfony/config": "^2.2|^3.0|^4.0|^5.0",
     "goetas-webservices/xsd-reader": "^0.3.7",
-    "doctrine/inflector": "^1.0",
+    "doctrine/inflector": "^2.0",
     "laminas/laminas-code": "^3.3.2",
 
     "psr/log": "^1.0"

--- a/src/Jms/YamlConverter.php
+++ b/src/Jms/YamlConverter.php
@@ -2,7 +2,7 @@
 
 namespace GoetasWebservices\Xsd\XsdToPhp\Jms;
 
-use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use Exception;
 use GoetasWebservices\XML\XSDReader\Schema\Attribute\AttributeContainer;
 use GoetasWebservices\XML\XSDReader\Schema\Attribute\AttributeItem;
@@ -379,8 +379,8 @@ class YamlConverter extends AbstractConverter
         $property['access_type'] = 'public_method';
         $property['serialized_name'] = $attribute->getName();
 
-        $property['accessor']['getter'] = 'get' . Inflector::classify($this->getNamingStrategy()->getPropertyName($attribute));
-        $property['accessor']['setter'] = 'set' . Inflector::classify($this->getNamingStrategy()->getPropertyName($attribute));
+        $property['accessor']['getter'] = 'get' . InflectorFactory::create()->build()->classify($this->getNamingStrategy()->getPropertyName($attribute));
+        $property['accessor']['setter'] = 'set' . InflectorFactory::create()->build()->classify($this->getNamingStrategy()->getPropertyName($attribute));
 
         $property['xml_attribute'] = true;
 
@@ -496,8 +496,8 @@ class YamlConverter extends AbstractConverter
             $property['xml_element']['namespace'] = $elementNamespace;
         }
 
-        $property['accessor']['getter'] = 'get' . Inflector::classify($this->getNamingStrategy()->getPropertyName($element));
-        $property['accessor']['setter'] = 'set' . Inflector::classify($this->getNamingStrategy()->getPropertyName($element));
+        $property['accessor']['getter'] = 'get' . InflectorFactory::create()->build()->classify($this->getNamingStrategy()->getPropertyName($element));
+        $property['accessor']['setter'] = 'set' . InflectorFactory::create()->build()->classify($this->getNamingStrategy()->getPropertyName($element));
         $t = $element->getType();
 
         if ($arrayize) {

--- a/src/Jms/YamlConverter.php
+++ b/src/Jms/YamlConverter.php
@@ -2,7 +2,7 @@
 
 namespace GoetasWebservices\Xsd\XsdToPhp\Jms;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\Inflector;
 use Exception;
 use GoetasWebservices\XML\XSDReader\Schema\Attribute\AttributeContainer;
 use GoetasWebservices\XML\XSDReader\Schema\Attribute\AttributeItem;

--- a/src/Naming/AbstractNamingStrategy.php
+++ b/src/Naming/AbstractNamingStrategy.php
@@ -2,7 +2,7 @@
 
 namespace GoetasWebservices\Xsd\XsdToPhp\Naming;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\Inflector;
 use GoetasWebservices\XML\XSDReader\Schema\Item;
 use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
 

--- a/src/Naming/AbstractNamingStrategy.php
+++ b/src/Naming/AbstractNamingStrategy.php
@@ -2,7 +2,7 @@
 
 namespace GoetasWebservices\Xsd\XsdToPhp\Naming;
 
-use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use GoetasWebservices\XML\XSDReader\Schema\Item;
 use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
 
@@ -99,11 +99,11 @@ abstract class AbstractNamingStrategy implements NamingStrategy
 
     public function getPropertyName($item)
     {
-        return Inflector::camelize(str_replace('.', ' ', $item->getName()));
+        return InflectorFactory::create()->build()->camelize(str_replace('.', ' ', $item->getName()));
     }
 
     protected function classify($name)
     {
-        return Inflector::classify(str_replace('.', ' ', $name));
+        return InflectorFactory::create()->build()->classify(str_replace('.', ' ', $name));
     }
 }

--- a/src/Naming/LongNamingStrategy.php
+++ b/src/Naming/LongNamingStrategy.php
@@ -2,7 +2,7 @@
 
 namespace GoetasWebservices\Xsd\XsdToPhp\Naming;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\Inflector;
 use GoetasWebservices\XML\XSDReader\Schema\Item;
 use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
 

--- a/src/Naming/LongNamingStrategy.php
+++ b/src/Naming/LongNamingStrategy.php
@@ -2,7 +2,7 @@
 
 namespace GoetasWebservices\Xsd\XsdToPhp\Naming;
 
-use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use GoetasWebservices\XML\XSDReader\Schema\Item;
 use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
 

--- a/src/Naming/NoConflictLongNamingStrategy.php
+++ b/src/Naming/NoConflictLongNamingStrategy.php
@@ -2,7 +2,7 @@
 
 namespace GoetasWebservices\Xsd\XsdToPhp\Naming;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\Inflector;
 use GoetasWebservices\XML\XSDReader\Schema\Item;
 use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
 

--- a/src/Naming/NoConflictLongNamingStrategy.php
+++ b/src/Naming/NoConflictLongNamingStrategy.php
@@ -2,7 +2,7 @@
 
 namespace GoetasWebservices\Xsd\XsdToPhp\Naming;
 
-use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use GoetasWebservices\XML\XSDReader\Schema\Item;
 use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
 

--- a/src/Naming/ShortNamingStrategy.php
+++ b/src/Naming/ShortNamingStrategy.php
@@ -2,7 +2,7 @@
 
 namespace GoetasWebservices\Xsd\XsdToPhp\Naming;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\Inflector;
 use GoetasWebservices\XML\XSDReader\Schema\Item;
 use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
 

--- a/src/Naming/ShortNamingStrategy.php
+++ b/src/Naming/ShortNamingStrategy.php
@@ -2,7 +2,7 @@
 
 namespace GoetasWebservices\Xsd\XsdToPhp\Naming;
 
-use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use GoetasWebservices\XML\XSDReader\Schema\Item;
 use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
 

--- a/src/Php/ClassGenerator.php
+++ b/src/Php/ClassGenerator.php
@@ -2,7 +2,7 @@
 
 namespace GoetasWebservices\Xsd\XsdToPhp\Php;
 
-use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass;
 use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClassOf;
 use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPProperty;
@@ -125,7 +125,7 @@ class ClassGenerator
 
         $type = $prop->getType();
 
-        $method = new MethodGenerator('set' . Inflector::classify($prop->getName()));
+        $method = new MethodGenerator('set' . InflectorFactory::create()->build()->classify($prop->getName()));
 
         $parameter = new ParameterGenerator($prop->getName());
 
@@ -186,7 +186,7 @@ class ClassGenerator
 
             $paramIndex = new ParameterGenerator('index');
 
-            $method = new MethodGenerator('isset' . Inflector::classify($prop->getName()), [$paramIndex]);
+            $method = new MethodGenerator('isset' . InflectorFactory::create()->build()->classify($prop->getName()), [$paramIndex]);
             $method->setDocBlock($docblock);
             $method->setBody('return isset($this->' . $prop->getName() . '[$index]);');
             $generator->addMethodFromGenerator($method);
@@ -204,7 +204,7 @@ class ClassGenerator
 
             $docblock->setTag(new ReturnTag('void'));
 
-            $method = new MethodGenerator('unset' . Inflector::classify($prop->getName()), [$paramIndex]);
+            $method = new MethodGenerator('unset' . InflectorFactory::create()->build()->classify($prop->getName()), [$paramIndex]);
             $method->setDocBlock($docblock);
             $method->setBody('unset($this->' . $prop->getName() . '[$index]);');
             $generator->addMethodFromGenerator($method);
@@ -242,7 +242,7 @@ class ClassGenerator
 
         $docblock->setTag($tag);
 
-        $method = new MethodGenerator('get' . Inflector::classify($prop->getName()));
+        $method = new MethodGenerator('get' . InflectorFactory::create()->build()->classify($prop->getName()));
         $method->setDocBlock($docblock);
         $method->setBody('return $this->' . $prop->getName() . ';');
 
@@ -269,7 +269,7 @@ class ClassGenerator
         $patramTag = new ParamTag($propName, $type->getArg()->getType()->getPhpType());
         $docblock->setTag($patramTag);
 
-        $method = new MethodGenerator('addTo' . Inflector::classify($prop->getName()));
+        $method = new MethodGenerator('addTo' . InflectorFactory::create()->build()->classify($prop->getName()));
 
         $parameter = new ParameterGenerator($propName);
         $tt = $type->getArg()->getType();

--- a/src/Php/ClassGenerator.php
+++ b/src/Php/ClassGenerator.php
@@ -2,7 +2,7 @@
 
 namespace GoetasWebservices\Xsd\XsdToPhp\Php;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\Inflector;
 use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass;
 use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClassOf;
 use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPProperty;

--- a/tests/JmsSerializer/OTA/OTASerializationTest.php
+++ b/tests/JmsSerializer/OTA/OTASerializationTest.php
@@ -2,7 +2,7 @@
 
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\JmsSerializer\OTA;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\Inflector;
 use GoetasWebservices\XML\XSDReader\SchemaReader;
 use GoetasWebservices\Xsd\XsdToPhp\Tests\Generator;
 use GoetasWebservices\Xsd\XsdToPhpRuntime\Jms\Handler\BaseTypesHandler;

--- a/tests/JmsSerializer/OTA/OTASerializationTest.php
+++ b/tests/JmsSerializer/OTA/OTASerializationTest.php
@@ -2,7 +2,7 @@
 
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests\JmsSerializer\OTA;
 
-use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use GoetasWebservices\XML\XSDReader\SchemaReader;
 use GoetasWebservices\Xsd\XsdToPhp\Tests\Generator;
 use GoetasWebservices\Xsd\XsdToPhpRuntime\Jms\Handler\BaseTypesHandler;
@@ -224,7 +224,7 @@ class OTASerializationTest extends \PHPUnit_Framework_TestCase
             if (is_file($dir . '/' . $name)) {
                 $tests[$n][0] = $file;
                 $tests[$n][1] = $dir . '/' . $name;
-                $tests[$n][2] = self::$namespace . '\\' . Inflector::classify(str_replace('.xsd', '', $name));
+                $tests[$n][2] = self::$namespace . '\\' . InflectorFactory::create()->build()->classify(str_replace('.xsd', '', $name));
             }
         }
 

--- a/tests/VeryShortNamingStrategy.php
+++ b/tests/VeryShortNamingStrategy.php
@@ -2,7 +2,7 @@
 
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests;
 
-use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
 
@@ -50,6 +50,6 @@ class VeryShortNamingStrategy extends ShortNamingStrategy
      */
     private function classify($name)
     {
-        return Inflector::classify(str_replace('.', ' ', $name));
+        return InflectorFactory::create()->build()->classify(str_replace('.', ' ', $name));
     }
 }

--- a/tests/VeryShortNamingStrategy.php
+++ b/tests/VeryShortNamingStrategy.php
@@ -2,7 +2,7 @@
 
 namespace GoetasWebservices\Xsd\XsdToPhp\Tests;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\Inflector;
 use GoetasWebservices\XML\XSDReader\Schema\Type\Type;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
 


### PR DESCRIPTION
Haven't really gone through everything, but this update does seem to work from what i can see. This makes it compatible to be installed alongside with symfony, as symfony currently uses Inflector 2.x