### PR TITLE
Fix And type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "authors": [
     {
       "name": "Asmir Mustafic",
-      "email" : "goetas@gmail.com"
+      "email": "goetas@gmail.com"
     }
   ],
   "keywords": [
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "require": {
-    "php": ">=7.2|^8.0",
+    "php": "^8.0",
     "symfony/console": "^2.7|^3.0|^4.0|^5.0|^6.0|^7.0",
     "symfony/dependency-injection": "^2.2|^3.0|^4.0|^5.0|^6.0|^7.0",
     "symfony/yaml": "^2.2|^3.0|^4.0|^5.0|^6.0|^7.0",


### PR DESCRIPTION
Support for `Any` type was added to xsd-reader in [#86](https://github.com/goetas-webservices/xsd-reader/pull/86) but noting was done on xsd2php.
This PR fixes conversion for schemas that use `Any` type.
Note that it removes PHP 7 support since I used union types.